### PR TITLE
:lipstick: Changed styling of toggleButton smaller

### DIFF
--- a/src/components/atoms/toggleButton/toggleButton.module.scss
+++ b/src/components/atoms/toggleButton/toggleButton.module.scss
@@ -9,6 +9,8 @@
 .toggleContainer {
   display: flex;
   height: 100%;
+  text-align: center;
+  align-items: center;
   input {
     min-width: 10%;
   }
@@ -16,8 +18,8 @@
 .switch {
   position: relative;
   display: inline-block;
-  width: 60px;
-  height: 34px;
+  width: 50px;
+  height: 28px;
   text-align: center;
   outline: none;
 }
@@ -38,10 +40,10 @@
 .slider:before {
   position: absolute;
   content: '';
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
+  height: 22px;
+  width: 22px;
+  left: 3px;
+  bottom: 3px;
   background-color: white;
   -webkit-transition: 0.4s;
   transition: 0.4s;
@@ -57,9 +59,9 @@ input:focus + .slider {
 }
 
 input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+  -webkit-transform: translateX(22px);
+  -ms-transform: translateX(22px);
+  transform: translateX(22px);
 }
 
 .textContainer {


### PR DESCRIPTION
### Proposal
:lipstick:  Changing styling of toggleButton to look more proportional
Size of button smaller.
Width of component changed from 100% to 100% of self. Easier to flex with this.
Put label right hand side of toggle. Looks better when aligning on toggle vs text.
![image](https://user-images.githubusercontent.com/34317459/207138489-97843555-4314-4002-b992-2e760fcf7dc2.png)

![image](https://user-images.githubusercontent.com/34317459/207138630-e318d2f0-e648-4612-8492-68a83c8f1ad8.png)
