### PR TITLE
Feature/extend eventform

### DIFF
--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -105,7 +105,7 @@ function handleResponse<T>(response: Response): Promise<T> {
   }
   // Handle empty responses and missing content-lenght header when the response is encoded
   if (
-    !response.headers.get('content-length') &&
+    response.headers.get('content-length') === '0' &&
     response.headers.get('content-encoding') === null
   ) {
     return {} as Promise<T>;

--- a/src/components/atoms/toggleButton/toggleButton.module.scss
+++ b/src/components/atoms/toggleButton/toggleButton.module.scss
@@ -2,12 +2,14 @@
 
 .container {
   display: flex;
-  justify-content: center;
   text-align: center;
   align-items: center;
 }
 .toggleContainer {
   display: flex;
+  justify-content: center;
+  text-align: center;
+  align-items: center;
   height: 100%;
   input {
     min-width: 10%;

--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -58,6 +58,7 @@
   flex-direction: column;
   justify-content: flex-start;
   text-align: left;
+  gap: 0.25rem;
 
   ol {
     max-height: 15vh;
@@ -87,4 +88,23 @@
 .header {
   min-height: 35vh;
   border-radius: 20px 20px 0px 0px;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  filter: invert(1);
+}
+
+input[type='time']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  filter: invert(1);
+}
+
+.toggleWrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 1rem;
+  gap: 0.25rem;
 }

--- a/src/components/molecules/event/eventButton/EventButton.tsx
+++ b/src/components/molecules/event/eventButton/EventButton.tsx
@@ -147,37 +147,43 @@ const AuthEventButton: React.FC<AuthButtonProps> = ({
         </Button>
       )}
       {showForm && (
-        <Modal maxWidth={100} title={'Join'} setIsOpen={setShowForm}>
+        <Modal maxWidth={100} title={'Påmelding'} setIsOpen={setShowForm}>
           <div className={styles.formContent}>
             <div className={styles.formToggles}>
-              <div>
+              {event?.food && (
+                <>
+                  <ToggleButton
+                    label={'Vil du ha mat på arragementet?'}
+                    onChange={() =>
+                      setJoinEventPayload({
+                        ...joinEventPayload,
+                        food: !joinEventPayload.food,
+                      })
+                    }></ToggleButton>
+                  <TextField
+                    label={'Allergier'}
+                    onChange={(e) => {
+                      setJoinEventPayload({
+                        ...joinEventPayload,
+                        dietaryRestrictions: e.target.value,
+                      });
+                    }}></TextField>
+                </>
+              )}
+              {event?.transportation && (
+                <>
+                  <ToggleButton
+                    label={'Har du behov for transport?'}
+                    onChange={() =>
+                      setJoinEventPayload({
+                        ...joinEventPayload,
+                        transportation: !joinEventPayload.transportation,
+                      })
+                    }></ToggleButton>
+                </>
+              )}
+            </div>
 
-            <ToggleButton
-              label={'Vil du ha mat på arragementet?'}
-              onChange={() =>
-                setJoinEventPayload({
-                  ...joinEventPayload,
-                  food: !joinEventPayload.food,
-                })
-              }></ToggleButton>
-              </div>
-            <ToggleButton
-              label={'Har du behov for transport?'}
-              onChange={() =>
-                setJoinEventPayload({
-                  ...joinEventPayload,
-                  transportation: !joinEventPayload.transportation,
-                })
-              }></ToggleButton>
-              </div>
-            <TextField
-              label={'Allergies'}
-              onChange={(e) => {
-                setJoinEventPayload({
-                  ...joinEventPayload,
-                  dietaryRestrictions: e.target.value,
-                });
-              }}></TextField>
             <Button version="secondary" onClick={joinEventAction}>
               Meld på
             </Button>

--- a/src/components/molecules/event/eventStatistics/EventStatistics.module.scss
+++ b/src/components/molecules/event/eventStatistics/EventStatistics.module.scss
@@ -1,5 +1,6 @@
 .content {
   width: 70vw;
+  margin-bottom: 10vh;
 }
 
 .chart_grid {

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -9,17 +9,22 @@ import {
   addressValidator,
   emptyFieldsValidator,
   priceValidator,
+  maxParticipantsValidator,
 } from 'utils/validators';
 import styles from './eventForm.module.scss';
 import Button from 'components/atoms/button/Button';
 import { createEvent, uploadEventPicture } from 'api';
 import { useHistory } from 'react-router-dom';
 import Textarea from 'components/atoms/textarea/Textarea';
+import ToggleButton from 'components/atoms/toggleButton/ToggleButton';
 
 const EventForm = () => {
   const [file, setFile] = useState<File | undefined>();
   const [error, setError] = useState<string | undefined>(undefined);
   const history = useHistory();
+  const [food, setFood] = useState<boolean>(false);
+  const [transportation, setTransportation] = useState<boolean>(false);
+
   const validators = {
     title: titleValidator,
     description: descriptionValidator,
@@ -27,6 +32,7 @@ const EventForm = () => {
     time: timeValidator,
     address: addressValidator,
     price: priceValidator,
+    maxParticipants: maxParticipantsValidator,
   };
 
   function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
@@ -47,14 +53,16 @@ const EventForm = () => {
     }
     try {
       const price = parseInt(fields['price']?.value);
+      const maxParticipants = parseInt(fields['maxParticipants']?.value);
       const resp = await createEvent({
         title: fields['title']?.value,
         description: fields['description']?.value,
         date: fields['date']?.value + ' ' + fields['time']?.value,
         address: fields['address']?.value,
+        maxParticipants: maxParticipants,
         price: price,
-        food: true,
-        transportation: true,
+        food: food,
+        transportation: transportation,
         active: false,
       });
       // TODO handle image upload errors separately
@@ -95,7 +103,7 @@ const EventForm = () => {
           onChange={onFieldChange}
           error={fields['title'].error}
         />
-        <br />
+
         <div className={styles.dateTimeWrapper}>
           <div className={styles.date}>
             <TextField
@@ -116,7 +124,7 @@ const EventForm = () => {
             />
           </div>
         </div>
-        <br />
+
         <TextField
           minWidth={35}
           name={'address'}
@@ -124,7 +132,15 @@ const EventForm = () => {
           onChange={onFieldChange}
           error={fields['address'].error}
         />
-        <br />
+
+        <Textarea
+          minWidth={33}
+          name={'description'}
+          label={'Beskrivelse'}
+          onChange={onFieldChange}
+          error={fields['description'].error}
+        />
+
         <TextField
           minWidth={35}
           name={'price'}
@@ -133,14 +149,32 @@ const EventForm = () => {
           onChange={onFieldChange}
           error={fields['price'].error}
         />
-        <br />
-        <Textarea
-          minWidth={33}
-          name={'description'}
-          label={'Beskrivelse'}
+        <TextField
+          minWidth={35}
+          name={'maxParticipants'}
+          label={'Maks antall deltagere'}
+          type={'number'}
           onChange={onFieldChange}
-          error={fields['description'].error}
+          error={fields['maxParticipants'].error}
         />
+        <div
+          style={{ display: 'flex', alignItems: 'flex-start', width: '100%' }}>
+          <ToggleButton
+            onChange={() => {
+              setFood(!food);
+            }}
+            label={'Servering av mat'}
+            initValue={food}></ToggleButton>
+        </div>
+        <div
+          style={{ display: 'flex', alignItems: 'flex-start', width: '100%' }}>
+          <ToggleButton
+            onChange={() => {
+              setTransportation(!transportation);
+            }}
+            label={'Mulighet for transport'}
+            initValue={transportation}></ToggleButton>
+        </div>
         <div className={styles.imgContainer}>
           <label>Last opp bilde til arrangementet </label>
           <input type="file" accept="image/*" onChange={handleFileUpload} />

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -2,14 +2,14 @@
 
 .eventForm {
   display: flex;
-  width: 100%;
   flex-direction: column;
   justify-content: center;
   align-items: center;
 }
 
 .eventContainer {
-  display: flex;
+  display: inline-flex;
+  gap: 1rem;
   width: 100%;
   flex-direction: column;
   justify-content: center;
@@ -28,8 +28,7 @@
 .dateTimeWrapper {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 5%;
-  // width: 100%;
+  width: 100%;
   justify-content: space-between;
   align-content: space-around;
 }

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -84,7 +84,13 @@ export interface Event {
 export type EventUpdate = Partial<
   Pick<
     Event,
-    'title' | 'description' | 'date' | 'address' | 'participants' | 'active'
+    | 'title'
+    | 'description'
+    | 'date'
+    | 'address'
+    | 'price'
+    | 'maxParticipants'
+    | 'active'
   >
 >;
 export type CreateEvent = Omit<Event, 'eid'>;


### PR DESCRIPTION
# :gear:  Event editing ++
Fixes a bug  in response handler to cooperate with JSON structure types.
Adds margin bottom to event statistics for better looks :lipstick: 
Joining an event will show only the fields that are applicable for the respective event.(Food allergies, transport, price)
Adds to editEvent:
- Food
- Transportation
- Date+time(dateTime)
- price

### Todo(?)
Not all fields are in updateEvent are validated, but implicitly a correct value. Should maybe add?

