### PR TITLE
Feature/member mail confirmation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   EventPage,
   EventAdmin,
   AdminPage,
+  ConfirmationPage,
 } from 'components/pages';
 import { PrivateRoute, AuthorizationRoute, AdminRoute } from 'routes';
 import Navbar from 'components/molecules/navbar/Navbar';
@@ -30,6 +31,7 @@ const App: React.FC = () => {
           <AdminRoute path="/admin" component={AdminPage} />
           <AdminRoute path="/event/:id/admin" component={EventAdmin} />
           <Route path="/event/:id" children={<EventPage />} />
+          <Route path="/confirmation/:confirmationCode" children={<ConfirmationPage />} />
           <Route path="/" component={HomePage} />
         </Switch>
       </ToastProvider>

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -27,3 +27,7 @@ export const changePassword = (passwordPayload: ChangePasswordPayload) =>
   post<ChangePasswordPayload>('auth/password', passwordPayload, true);
 
 export const getAllMembers = () => get<Array<Member>>('members/', true);
+
+export const confirmMember = (confimationCode: string) => post<{}>('member/confirm/' + confimationCode, '')
+
+export const sendNewVerificationEmail = (email: string) => post<{}>('member/confirm/code/' + email, '')

--- a/src/components/pages/confirmation/ConfirmationPage.tsx
+++ b/src/components/pages/confirmation/ConfirmationPage.tsx
@@ -10,16 +10,15 @@ const ConfirmationPage: React.FC = () => {
     const history = useHistory();
 
     var confirm = async function () {
-        var succ: ToastStatus = "success"
+        var status: ToastStatus = "success"
         var title: string = "User confirmed."
         try {
             await confirmMember(confirmationCode)
         } catch (error) {
-            console.log(error)
-            succ = "error"
+            status = "error"
             title = "Confirmation code not found."
         }
-        addToast({ status: succ, title: title })
+        addToast({ status: status, title: title })
         history.push('/')
     }
     useEffect(() => { confirm() }, [])

--- a/src/components/pages/confirmation/ConfirmationPage.tsx
+++ b/src/components/pages/confirmation/ConfirmationPage.tsx
@@ -1,0 +1,29 @@
+import { confirmMember } from "api";
+import { ToastStatus } from "contexts/toastProvider";
+import { useToast } from "hooks/useToast";
+import { useEffect } from "react";
+import { useHistory, useParams } from "react-router-dom";
+
+const ConfirmationPage: React.FC = () => {
+    const { confirmationCode } = useParams<{ confirmationCode: string }>();
+    const { addToast } = useToast();
+    const history = useHistory();
+
+    var confirm = async function () {
+        var succ: ToastStatus = "success"
+        var title: string = "User confirmed."
+        try {
+            await confirmMember(confirmationCode)
+        } catch (error) {
+            console.log(error)
+            succ = "error"
+            title = "Confirmation code not found."
+        }
+        addToast({ status: succ, title: title })
+        history.push('/')
+    }
+    useEffect(() => { confirm() }, [])
+
+    return (<></>)
+}
+export default ConfirmationPage

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -7,6 +7,7 @@ import CreateEvent from './events/createEvent/CreateEvent';
 import EventPage from './events/eventPage/EventPage';
 import EventAdmin from './events/eventAdmin/EventAdmin';
 import AdminPage from './admin/AdminPage';
+import ConfirmationPage from './confirmation/ConfirmationPage';
 
 export {
   RegistrerPage,
@@ -18,4 +19,5 @@ export {
   EventPage,
   EventAdmin,
   AdminPage,
+  ConfirmationPage,
 };

--- a/src/components/pages/profile/Profile.tsx
+++ b/src/components/pages/profile/Profile.tsx
@@ -1,19 +1,21 @@
 import { useState, useEffect } from 'react';
 import styles from './profile.module.scss';
 import useTitle from 'hooks/useTitle';
-import { PartialMember } from 'models/apiModels';
-import { getMemberAssociatedWithToken } from 'api';
+import { Member, PartialMember } from 'models/apiModels';
+import { getMemberAssociatedWithToken,sendNewVerificationEmail } from 'api';
+import Button from 'components/atoms/button/Button';
 
 const ProfilePage = () => {
-  const [data, setData] = useState<PartialMember>();
+  const [data, setData] = useState<Member>();
   useTitle('Min profil');
 
   useEffect(() => {
     (async function getUserInfo() {
-      const response = (await getMemberAssociatedWithToken()) as PartialMember;
+      const response = (await getMemberAssociatedWithToken()) as Member;
       setData(response);
     })();
   }, []);
+  
   const items = [
     { lable: 'Navn', data: data?.realName },
     { lable: 'E-post', data: data?.email },
@@ -40,6 +42,16 @@ const ProfilePage = () => {
           )}
         </div>
       </div>
+      {data?.role == "unconfirmed" &&
+        <div>
+          <p>
+            Seems like you have not verified your user, please click on the verification link sent to your email address
+          </p>
+          <Button version='secondary' onClick={async () => { await sendNewVerificationEmail(data.email)}}>
+            Click here to get new verification email.
+          </Button>
+        </div>
+      }
     </div>
   );
 };


### PR DESCRIPTION
# :gem: Changes
- Add a confirmation page that a new member is pointed to from a verification URL.
  - When the member is confirmed, the user is redirected to the home page
- Notification on the profile page if the user is not confirmed, with a button that resends a confirmation email.

# 
This resolves #45, and needs td-org-uit-no/tdctl-api#47 to be resolved before use.

<!-- Forklar hva du endrer og HVORFOR. Bruk gjerne en liste,
eller del det opp i seksjoner hvis det er mye e.g
- En ting
  -  En underting
- En annen ting

Du kan også laste opp et bilde av endringen, ved å lime det inn her. Det anbefales.
-->
