### PR TITLE
:lipstick: make footer responsive for mobile devices

### DIFF
--- a/src/components/molecules/footer/Footer.tsx
+++ b/src/components/molecules/footer/Footer.tsx
@@ -36,7 +36,7 @@ const FooterItem: React.FC<FooterItemProps> = ({ label, path, header }) => {
 };
 
 // TODO add relevant paths
-const Footer = () => {
+const Footer:React.FC = () => {
   return (
     <div className={styles.footerContainer}>
       <div className={styles.footerWrapper}>

--- a/src/components/molecules/footer/footer.module.scss
+++ b/src/components/molecules/footer/footer.module.scss
@@ -21,6 +21,7 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
+  word-break: break-all;
 }
 
 .listWrapper {
@@ -28,11 +29,12 @@
   flex-direction: column;
   text-align: left;
   justify-content: center;
+  margin: 0 .5rem 0 .5rem;
 }
 
 .footerListContainer h5 {
+  margin: .5rem 0 1rem;
   color: $off-primary;
-  margin: 0;
 }
 
 .footerItemContainer {
@@ -59,5 +61,20 @@
     &:hover {
       text-decoration: underline;
     }
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .footerContainer {
+    flex-direction: column;
+  }
+  .footerWrapper {
+    width: 100%;
+  }
+}
+
+@media screen and (max-width: 525px) {
+  .logosContainer{
+    display: none;
   }
 }

--- a/src/components/molecules/footer/footerLogos/footerLogos.module.scss
+++ b/src/components/molecules/footer/footerLogos/footerLogos.module.scss
@@ -11,12 +11,18 @@
 }
 .wrapper {
   display: flex;
-  width: 50%;
   justify-content: space-evenly;
   border-bottom: 1px solid;
 }
 
 .logoItem {
   margin-bottom: 0.25rem;
+  margin: 0 1rem 0 1rem;
   cursor: pointer;
+}
+
+@media screen and (max-width: 800px) {
+  .logosContainer {
+    display: none;
+  }
 }


### PR DESCRIPTION
## :iphone: Make footer responsive for mobile units
  - ### :warning:  This changes removes the logos for mobile units
  - :heavy_check_mark:  resolves #56 
![Screenshot from 2023-01-04 00-05-25](https://user-images.githubusercontent.com/43537864/210456019-c9c18285-cc73-4592-b4d6-00b77262b6f9.png)
#### Smaller devices :arrow_down: 
![Screenshot from 2023-01-04 00-06-24](https://user-images.githubusercontent.com/43537864/210456097-9a926db9-b099-4084-a696-e48e03f965c3.png)
