### PR TITLE
:lipstick: add mobile view to createEvent molecule

### DIFF
--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -107,7 +107,6 @@ const EventForm = () => {
         <div className={styles.dateTimeWrapper}>
           <div className={styles.date}>
             <TextField
-              minWidth={14}
               name={'date'}
               label={'Dato'}
               type={'date'}
@@ -116,7 +115,6 @@ const EventForm = () => {
           </div>
           <div className={styles.time}>
             <TextField
-              minWidth={12}
               name={'time'}
               label={'Tid'}
               type={'time'}
@@ -126,7 +124,6 @@ const EventForm = () => {
         </div>
 
         <TextField
-          minWidth={35}
           name={'address'}
           label={'Adresse'}
           onChange={onFieldChange}
@@ -134,7 +131,6 @@ const EventForm = () => {
         />
 
         <Textarea
-          minWidth={33}
           name={'description'}
           label={'Beskrivelse'}
           onChange={onFieldChange}
@@ -142,7 +138,6 @@ const EventForm = () => {
         />
 
         <TextField
-          minWidth={35}
           name={'price'}
           label={'Pris'}
           type={'number'}
@@ -150,7 +145,6 @@ const EventForm = () => {
           error={fields['price'].error}
         />
         <TextField
-          minWidth={35}
           name={'maxParticipants'}
           label={'Maks antall deltagere'}
           type={'number'}

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -27,6 +27,7 @@
 
 .dateTimeWrapper {
   display: grid;
+  gap: 0.5rem;
   grid-template-columns: repeat(2, 1fr);
   width: 100%;
   justify-content: space-between;

--- a/src/styles/text.scss
+++ b/src/styles/text.scss
@@ -2,6 +2,7 @@
 
 .container {
   position: relative;
+  display: flex;
   flex-direction: column;
   width: 100%;
   justify-content: flex-start;
@@ -86,21 +87,20 @@ input:-webkit-autofill:active {
   overflow-wrap: break-word;
   max-width: inherit;
   p {
-    margin: .25rem 0 0 1rem;
+    margin: 0.25rem 0 0 1rem;
   }
 }
 
 @media screen and (max-width: 450px) {
-  .container{
+  .container {
     display: flex;
     justify-content: flex-start;
     input {
       // override user input on smaller devices
       min-width: 0px !important;
-   }
+    }
   }
   .errors {
     font-size: 12px;
   }
 }
-


### PR DESCRIPTION
# :lipstick: adapt event form to mobile views
Change styling to create event form to adapt mobile view better. 
:muscle: Removed hard-coded widths for inputs and letting them flex 100%.

![image](https://user-images.githubusercontent.com/34317459/212545904-dfb66caf-9e2f-4829-9887-bdf989f2d100.png)
