### PR TITLE
Fix/update event on undefined max participants

### DIFF
--- a/src/components/molecules/event/eventBody/EventBody.tsx
+++ b/src/components/molecules/event/eventBody/EventBody.tsx
@@ -205,17 +205,19 @@ export const EditEvent: React.FC<{ event: Event; setEdit: () => void }> = ({
                   <ToggleButton
                     initValue={toggleFood}
                     onChange={() => setToggleFood(!toggleFood)}
-                    label={'Food'}></ToggleButton>
+                    label={'Matservering'}></ToggleButton>
                   <ToggleButton
                     initValue={toggleTransportation}
                     onChange={() =>
                       setToggleTransportation(!toggleTransportation)
                     }
-                    label={'Transportation'}></ToggleButton>
+                    label={'Transport'}></ToggleButton>
                   <ToggleButton
                     initValue={togglePublic}
                     onChange={() => setTogglePublic(!togglePublic)}
-                    label={togglePublic ? 'Public' : 'Private'}></ToggleButton>
+                    label={
+                      togglePublic ? 'Offentlig' : 'Privat'
+                    }></ToggleButton>
                 </div>
               </div>
             </div>

--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  margin-top: 1rem;
 }
 
 .contentContainer {

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -35,6 +35,8 @@ const EventForm = () => {
     price: priceValidator,
     maxParticipants: maxParticipantsValidator,
   };
+  // allows maxParticipants to be empty
+  const optionalKeys = ['maxParticipants'];
 
   function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
     if (event.target.files) {
@@ -45,6 +47,7 @@ const EventForm = () => {
   const submit = async () => {
     const emptyFields = emptyFieldsValidator({
       fields: fields,
+      optFields: optionalKeys,
     });
 
     emptyFields ? setError('Alle feltene må fylles ut') : setError(undefined);

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -42,12 +42,13 @@ export const passwordValidator = (password: string): string[] | undefined => {
   return errors.length > 0 ? errors : undefined;
 };
 
+// allows field to be undefined i.e optional validator
 export const maxParticipantsValidator = (
   maxParticipants: string | undefined
 ): string[] | undefined => {
   if (maxParticipants !== undefined) {
     if (parseInt(maxParticipants) < 0) {
-      return ['max antall kan ikke være negativt'];
+      return ['Maks antall kan ikke være negativt'];
     }
   }
   return undefined;
@@ -133,7 +134,9 @@ export const timeValidator = (time: string) => {
 
 // description length constraint
 export const descriptionValidator = (description: string) => {
-  return description.length >= 1000 ? ['Beskrivelse er for lang'] : undefined;
+  return description.length
+    ? undefined
+    : ['Arrangement beskrivelse må fylles ut'];
 };
 
 interface InputFields {
@@ -141,6 +144,8 @@ interface InputFields {
   optFields?: string[];
 }
 
+// validates if fields all required fields are filled
+// optFields array of keys which are allowed to be empty
 export const emptyFieldsValidator = ({ fields, optFields }: InputFields) => {
   return (
     Object.keys(fields).filter((key) => {


### PR DESCRIPTION
## :hammer_and_wrench: fix removal of optional field such as maxParticipants in event update
  - fields to be removed should be set to null and not as undefined as this will be seen as an empty field by the API 
### Minor fixes:
  - fixes #81 
  - resolves #78 
