### PR TITLE
Ux/remove attendees number form user

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Nettsiden til Tromsøstudentenes Dataforening" />
-  <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');
-  </style>
-  <link rel="stylesheet"
-        href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
-  <!--
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta
+            name="description"
+            content="Website for Tromsøstudentenes Dataforening"
+        />
+        <style>
+            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');
+        </style>
+        <link
+            rel="stylesheet"
+            href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css"
+        />
+        <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <!--
+        <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -25,13 +29,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>Tromsøstudentenes Dataforening</title>
-</head>
+        <title>Tromsøstudentenes Dataforening</title>
+    </head>
 
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-  <!--
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -40,7 +44,5 @@
 
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
-
+    --></body>
 </html>

--- a/src/components/molecules/event/eventButton/EventButton.tsx
+++ b/src/components/molecules/event/eventButton/EventButton.tsx
@@ -97,7 +97,7 @@ const AuthEventButton: React.FC<AuthButtonProps> = ({
 
   const joinEventAction = async () => {
     try {
-      const res = await joinEvent(id, joinEventPayload);
+      await joinEvent(id, joinEventPayload);
 
       setIsjoined(!isJoined);
       setShowForm(false);
@@ -110,14 +110,6 @@ const AuthEventButton: React.FC<AuthButtonProps> = ({
         }
       }
 
-      if (typeof res !== 'string' && res.max) {
-        addToast({
-          title: 'Info',
-          status: 'info',
-          description: 'Arrangementet er fullt, du er satt på venteliste',
-        });
-        return;
-      }
       addToast({
         title: 'Suksess',
         status: 'success',


### PR DESCRIPTION
## :anger: Remove info about the number of participants who joined an event with limited spots
  - As pointed out in #101. Users may drop joining events when they know the event is full. 
### :sparkles: Suggested changes: 
  - Events with limited spots: 
![image](https://user-images.githubusercontent.com/43537864/219964599-ee76cb56-9220-4df9-9012-ff56bb2eae89.png)
  - Events with no limitation: 
![image](https://user-images.githubusercontent.com/43537864/219964463-da4eb6f8-edab-4050-9dfd-7d7e77a0abf9.png)
  - Admin: 
![image](https://user-images.githubusercontent.com/43537864/219964792-56d56c8e-9e57-4bf6-a571-e1718fc28cc4.png)

  
