### PR TITLE
:sparkles: automatically add issues to project backlog

### DIFF
--- a/.github/workflows/add_issues_to_project_backlog.yml
+++ b/.github/workflows/add_issues_to_project_backlog.yml
@@ -1,0 +1,18 @@
+name: Add new issue to project backlog
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-issue-to-project:
+    name: Add issue to project backlog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          # 2 -> master backlog for frontend
+          # project automatically sets new items to "Issue under review" column
+          project-url: https://github.com/orgs/td-org-uit-no/projects/2
+          github-token: ${{ secrets.ISSUE_TO_PROJECT_PAT }}


### PR DESCRIPTION
## :sparkles: Action to add issues to master backlog
  - :warning: This action is not tested as the action cannot be triggered unless added to the master branch