### PR TITLE
Feature/event reorder and confirmation

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -4,6 +4,7 @@ import {
   Participant,
   Event,
   JoinEventPayload,
+  ParticipantsUpdate,
 } from 'models/apiModels';
 import { get, post, put, Delete } from './requests';
 
@@ -47,3 +48,16 @@ export const deleteParticipant = (
 
 export const exportEvent = (eid: string): Promise<{}> =>
   get<{}>('event/' + eid + '/export', true);
+
+export const confirmEvent = (eid: string): Promise<{}> =>
+  post<{}>('event/' + eid + '/confirm', {}, true);
+
+export const reorderParticipants = (
+  eid: string,
+  updateList: { updateList: ParticipantsUpdate[] }
+): Promise<{}> =>
+  put<{ updateList: ParticipantsUpdate[] }>(
+    'event/' + eid + '/updateParticipantsOrder',
+    updateList,
+    true
+  );

--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -5,10 +5,22 @@ import { renewToken } from './auth';
 /* Http error */
 export class HttpError extends Error {
   statusCode: number;
-  constructor(message: string, statusCode: number) {
+  text: Promise<string>;
+  constructor(message: string, statusCode: number, text: Promise<string>) {
     super(message);
     this.statusCode = statusCode;
+    this.text = text;
   }
+
+  public getText = async () => {
+    try {
+      let res = await this.text;
+      const reason = JSON.parse(res);
+      return reason.detail;
+    } catch (error) {
+      return '';
+    }
+  };
 }
 
 export const get = async <T>(
@@ -102,7 +114,7 @@ const authFetch = <T>(request: Request) => {
 
 function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
-    throw new HttpError(response.statusText, response.status);
+    throw new HttpError(response.statusText, response.status, response.text());
   }
   // Handle empty responses and missing content-lenght header when the response is encoded
   if (

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -6,11 +6,19 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   version: 'primary' | 'secondary';
 }
 
-const Button: React.FC<Props> = ({ children, version, className, ...rest }) => {
-  const classes = classnames(version, className);
+const Button: React.FC<Props> = ({
+  children,
+  version,
+  className,
+  disabled,
+  ...rest
+}) => {
+  const classes = disabled
+    ? classnames(className)
+    : classnames(version, className);
 
   return (
-    <button className={classes} {...rest}>
+    <button className={classes} disabled={disabled} {...rest}>
       {children}
     </button>
   );

--- a/src/components/atoms/button/button.scss
+++ b/src/components/atoms/button/button.scss
@@ -27,6 +27,13 @@ button {
   }
 }
 
+button:disabled,
+button[disabled] {
+  background-color: #797a7d;
+  color: #333333;
+  cursor: not-allowed;
+}
+
 .primary {
   color: $primary;
   border-color: $off-primary;

--- a/src/components/atoms/table/Table.tsx
+++ b/src/components/atoms/table/Table.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState } from 'react';
+import {
+  useEffect,
+  useState,
+  DragEvent,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { SortOption, typeToFunction } from 'utils/sorting';
 import './table.scss';
 // extends https://www.bekk.christmas/post/2020/22/create-a-generic-table-with-react-and-typescript
@@ -14,19 +20,30 @@ export type ColumnDefinitionType<T, K extends keyof T> = {
 
 type TableProps<T, K extends keyof T> = {
   data: Array<T>;
+  setData?: Dispatch<SetStateAction<Array<T>>>;
   columns: Array<ColumnDefinitionType<T, K>>;
+  showIdx?: boolean;
   type?: keyof SortOption;
+  dragable?: boolean;
+  sort?: boolean;
+  mark?: number;
 };
 
 type TableHeaderProps<T, K extends keyof T> = {
   columns: Array<ColumnDefinitionType<T, K>>;
   setColumn: (column: SortColumn<T, K>) => void;
+  showIdx?: boolean;
 };
 
 type TableRowsProps<T, K extends keyof T> = {
   data: Array<T>;
+  setData?: Dispatch<SetStateAction<Array<T>>>;
   columns: Array<ColumnDefinitionType<T, K>>;
   selectedColumn: SortColumn<T, K>;
+  showIdx?: boolean;
+  dragble?: boolean;
+  sort?: boolean;
+  mark?: number;
 };
 
 type SortColumn<T, K extends keyof T> = {
@@ -34,7 +51,15 @@ type SortColumn<T, K extends keyof T> = {
   sortType: keyof SortOption;
 };
 
-const Table = <T, K extends keyof T>({ data, columns }: TableProps<T, K>) => {
+const Table = <T, K extends keyof T>({
+  data,
+  setData,
+  columns,
+  showIdx = false,
+  dragable = false,
+  sort = true,
+  mark,
+}: TableProps<T, K>) => {
   const initColumn = {
     columnName: columns[0].cell as K,
     // defaults to number as its a straight comparison a < b
@@ -45,11 +70,20 @@ const Table = <T, K extends keyof T>({ data, columns }: TableProps<T, K>) => {
 
   return (
     <table className={'table'}>
-      <TableHeader columns={columns} setColumn={setSelectedColumn} />
+      <TableHeader
+        columns={columns}
+        setColumn={setSelectedColumn}
+        showIdx={showIdx}
+      />
       <TableRows
         data={data}
+        setData={setData}
         columns={columns}
         selectedColumn={selectedColumn}
+        showIdx={showIdx}
+        dragble={dragable}
+        sort={sort}
+        mark={mark}
       />
     </table>
   );
@@ -58,6 +92,7 @@ const Table = <T, K extends keyof T>({ data, columns }: TableProps<T, K>) => {
 const TableHeader = <T, K extends keyof T>({
   columns,
   setColumn,
+  showIdx,
 }: TableHeaderProps<T, K>) => {
   const onColumnClick = (column: ColumnDefinitionType<T, K>) => {
     const selected = {
@@ -70,6 +105,7 @@ const TableHeader = <T, K extends keyof T>({
   return (
     <thead>
       <tr>
+        {showIdx && <th>{'Indeks'}</th>}
         {columns.map((column, index) => {
           return (
             <th key={`headCell-${index}`} onClick={() => onColumnClick(column)}>
@@ -84,10 +120,17 @@ const TableHeader = <T, K extends keyof T>({
 
 const TableRows = <T, K extends keyof T>({
   data,
+  setData,
   columns,
   selectedColumn,
+  showIdx = false,
+  dragble = false,
+  sort = true,
+  mark,
 }: TableRowsProps<T, K>) => {
   const [sortedData, setSortedData] = useState<Array<T>>(data);
+  const [pos, setPos] = useState<number | undefined>();
+  const [dragOver, setDragover] = useState<number | undefined>();
 
   function OrderByArray(values: Array<T>, orderType: K) {
     const func = typeToFunction[selectedColumn.sortType];
@@ -96,18 +139,58 @@ const TableRows = <T, K extends keyof T>({
   }
 
   useEffect(() => {
+    if (setData) {
+      setData(sortedData);
+    }
+  }, [sortedData]);
+
+  useEffect(() => {
+    if (sort === false) {
+      return;
+    }
     OrderByArray(sortedData, selectedColumn.columnName as K);
   }, [selectedColumn]);
 
   useEffect(() => {
+    if (sort === false) {
+      setSortedData(data);
+      return;
+    }
     OrderByArray(data, selectedColumn.columnName as K);
   }, [data]);
+
+  const dragStart = (_e: DragEvent<HTMLDivElement>, position: number) => {
+    setPos(position);
+  };
+
+  const dragEnter = (_e: DragEvent<HTMLDivElement>, position: any) => {
+    setDragover(position);
+  };
+
+  const drop = () => {
+    const copyListItems = [...sortedData];
+    if (pos !== undefined && dragOver !== undefined) {
+      const dragItemContent = copyListItems[pos];
+      copyListItems.splice(pos, 1);
+      copyListItems.splice(dragOver, 0, dragItemContent);
+    }
+    setPos(undefined);
+    setDragover(undefined);
+    setSortedData(copyListItems);
+  };
 
   return (
     <tbody>
       {sortedData.map((row, index) => {
         return (
-          <tr key={`row-${index}`}>
+          <tr
+            key={`row-${index}`}
+            draggable={dragble}
+            onDragStart={(e) => dragStart(e, index)}
+            onDragEnter={(e) => dragEnter(e, index)}
+            onDragEnd={drop}
+            className={index === mark ? 'marked' : undefined}>
+            {showIdx && <td key={index}>{index}</td>}
             {columns.map((column, index2) => {
               return (
                 <td key={`cell-${index2}`}>

--- a/src/components/atoms/table/table.scss
+++ b/src/components/atoms/table/table.scss
@@ -8,7 +8,6 @@
   min-width: 400px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
   border: 0.1em #303342 solid;
-  overflow-x: auto;
   width: 100%;
 }
 
@@ -34,6 +33,9 @@ $border-radius: 5px;
   border-bottom: thin solid white;
   color: $primary;
   text-align: left;
+}
+.marked {
+  border-top: thin solid #50c742;
 }
 
 .table th,

--- a/src/components/molecules/event/eventResponses/EventResponses.tsx
+++ b/src/components/molecules/event/eventResponses/EventResponses.tsx
@@ -74,9 +74,9 @@ const EventResponses: React.FC<{
     try {
       await confirmEvent(event.eid);
       addToast({
-        title: 'Success',
+        title: 'Bekreftelse sent',
         status: 'success',
-        description: `Confirmation success! Email sent to all current participants`,
+        description: `Bekreftelses mail er sendt ut til alle som har plass`,
       });
       setFetchUpdateHook(true);
     } catch (error) {
@@ -91,9 +91,9 @@ const EventResponses: React.FC<{
           break;
         default:
           addToast({
-            title: 'Error',
+            title: 'En uforutsett feil skjedde',
             status: 'error',
-            description: `Unexpected error when submitting`,
+            description: 'Kunne ikke sende ut bekreftelse',
           });
       }
     }
@@ -112,25 +112,25 @@ const EventResponses: React.FC<{
       setFetchUpdateHook(true);
 
       addToast({
-        title: 'Success',
+        title: 'Suksess',
         status: 'success',
         description: `${selectedParticipant?.realName} fjernet fra ${event.title}`,
       });
     } catch (error) {
       switch (error.statusCode) {
-        case 403:
+        case 400:
           addToast({
-            title: 'Error',
+            title: 'Feil',
             status: 'error',
-            description: `403 -  Not allowed`,
+            description: 'Brukeren er ikke meldt på arrangementet',
           });
           break;
 
         default:
           addToast({
-            title: 'Error',
+            title: 'En uforutsett feil skjedde',
             status: 'error',
-            description: `Unexpected error when removing ${selectedParticipant?.realName}`,
+            description: `kunne ikke fjerne ${selectedParticipant?.realName}`,
           });
       }
     }
@@ -219,7 +219,6 @@ const EventResponses: React.FC<{
         description: 'Påmeldings listen er oppdatert!"',
       });
     } catch (error) {
-      // let text = await getText(error.text);
       let detail = await error.getText();
       if (error.statusCode === 400) {
         // forwards error from API

--- a/src/components/molecules/event/eventResponses/eventResponses.module.scss
+++ b/src/components/molecules/event/eventResponses/eventResponses.module.scss
@@ -1,0 +1,15 @@
+.submitWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: right;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.submitModalButtons {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -30,6 +30,8 @@ export interface Participant {
   transportation: boolean;
   dietaryRestrictions?: string;
   submitDate: string;
+  penalty: number;
+  confirmed?: boolean;
 }
 
 export interface TokenPair {
@@ -82,6 +84,7 @@ export interface Event {
   transportation: boolean;
   public: boolean;
   registrationOpeningDate?: string;
+  confirmed?: boolean;
 }
 
 export type EventUpdate = Partial<
@@ -94,6 +97,7 @@ export type EventUpdate = Partial<
     | 'price'
     | 'maxParticipants'
     | 'public'
+    | 'confirmed'
   >
 >;
 export type CreateEvent = Omit<Event, 'eid' | 'host'>;
@@ -118,5 +122,7 @@ export interface JobItem {
   start_date?: Date;
   due_date?: Date;
 }
+
+export type ParticipantsUpdate = Pick<Participant, 'id'> & { pos: number };
 
 export type CreateJob = Omit<JobItem, 'id'>;


### PR DESCRIPTION
## :sparkles: Re-order and confirmation 
Allows admin to reorder event participant list and send out confirmation mail. This resolves #107 and closes #108
  - #### :warning: dependent on td-org-uit-no/tdctl-api#71
  - The reorder and confirmation feedback can and should be improved, however the core functionality and feedback is present.
  - Since there several 400 responses the frontend only forwards the message, meaning they will be in English. imo this is acceptable as only a handful people will be using this page
### Minor changes:
  - add styling for disabled buttons
  - Extends HttpError to include response.text() promise 
     - adding method for getting the value from the promise 