### PR TITLE
Fix/event image upload error handling

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -11,8 +11,11 @@ import { get, post, put, Delete } from './requests';
 export const createEvent = (event: CreateEvent): Promise<{ eid: string }> =>
   post<{ eid: string }>('event/', event);
 
-export const uploadEventPicture = (id: string, eventImage: any) =>
-  post<{}>('event/' + id + '/image', eventImage, 'multipart/form-data');
+export const uploadEventPicture = async (id: string, imageFile: File) => {
+  const data = new FormData();
+  data.append('image', imageFile, imageFile.name);
+  await post<{}>('event/' + id + '/image', data, 'multipart/form-data');
+};
 
 export const getEventById = (id: string): Promise<Event> =>
   get<Event>('event/' + id);

--- a/src/api/jobs.ts
+++ b/src/api/jobs.ts
@@ -10,8 +10,11 @@ export const getJob = (id: string): Promise<JobItem> =>
 export const createJob = (job: CreateJob): Promise<{ id: string }> =>
   post<{ id: string }>('jobs/', job);
 
-export const uploadJobPicture = (id: string, jobImage: any) =>
-  post<{}>('jobs/' + id + '/image', jobImage, 'multipart/form-data');
+export const uploadJobPicture = async (id: string, jobImage: File) => {
+  const data = new FormData();
+  data.append('image', jobImage, jobImage.name);
+  await post<{}>('jobs/' + id + '/image', data, 'multipart/form-data');
+};
 
 export const getJobImage = (id: string): Promise<{ image: any }> =>
   get<{ image: any }>('jobs/' + id + '/image');

--- a/src/components/atoms/fileSelector/FileSelector.tsx
+++ b/src/components/atoms/fileSelector/FileSelector.tsx
@@ -1,0 +1,58 @@
+import React, { InputHTMLAttributes, useRef, useState } from 'react';
+import './fileSelector.scss';
+
+interface IFileSelector extends InputHTMLAttributes<HTMLInputElement> {
+  setFile: (file: File) => void;
+  text: string;
+  fileValidator?: (file: File) => string | undefined;
+}
+
+const FileSelector: React.FC<IFileSelector> = ({
+  setFile,
+  text,
+  fileValidator,
+  ...rest
+}) => {
+  const [errorMsg, setErrorMsg] = useState<string | undefined>();
+  const inputRef = useRef<HTMLInputElement>(null);
+  // remove type from rest to ensure type="file"
+  const { type, ...filteredProps } = rest;
+
+  function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
+    if (event.target.files == null || !event.target.files?.length) {
+      // catch file selector opened but no file selected
+      return;
+    }
+    const file = event.target.files[0];
+    const validatorError = fileValidator && fileValidator(file);
+
+    if (validatorError) {
+      setErrorMsg(validatorError);
+      resetInputValue();
+      return;
+    }
+    setErrorMsg(undefined);
+    setFile(file);
+  }
+
+  function resetInputValue() {
+    if (inputRef.current !== null) {
+      inputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="fileSelector">
+      <label>{text}</label>
+      <input
+        ref={inputRef}
+        type="file"
+        {...filteredProps}
+        onChange={handleFileUpload}
+      />
+      {errorMsg && <p>{errorMsg}</p>}
+    </div>
+  );
+};
+
+export default FileSelector;

--- a/src/components/atoms/fileSelector/fileSelector.scss
+++ b/src/components/atoms/fileSelector/fileSelector.scss
@@ -1,0 +1,31 @@
+@import 'src/styles/colors';
+
+.fileSelector {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 1rem;
+  width: 100%;
+  text-align: center;
+
+  input {
+    width: auto;
+  }
+}
+
+input[type='file']::file-selector-button {
+  padding: 0.5em 2em;
+  margin: 0.25rem 0.25rem 0.25rem;
+  border-color: #444658;
+  background-color: transparent;
+  border: 1px solid;
+  border-radius: 0.5rem;
+  color: $secondary;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+input[type='file']::file-selector-button:hover {
+  background: $off-primary;
+}

--- a/src/components/molecules/confirmationBox/ConfirmationBox.tsx
+++ b/src/components/molecules/confirmationBox/ConfirmationBox.tsx
@@ -6,21 +6,25 @@ interface ConformationProps {
   title?: string;
   onDecline: () => void;
   onAccept: () => void;
+  confirmText?: string;
+  declineText?: string;
 }
 
 const ConfirmationBox: React.FC<ConformationProps> = ({
   title,
   onDecline,
   onAccept,
+  confirmText,
+  declineText,
 }) => {
   return (
     <div className={styles.confirmWrapper}>
       <p>{title}</p>
       <Button version="secondary" onClick={onAccept}>
-        Ja
+        {confirmText ?? 'Ja'}
       </Button>
       <Button version="secondary" onClick={onDecline}>
-        Nei
+        {declineText ?? 'Nei'}
       </Button>
     </div>
   );

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useForm from 'hooks/useForm';
 import TextField from 'components/atoms/textfield/Textfield';
 import {
@@ -86,7 +86,6 @@ const EventForm: React.FC = () => {
         registrationOpeningDate: regDate,
       });
       setEid(resp.eid);
-      // TODO handle image upload errors separately
       if (file) {
         const data = new FormData();
         data.append('image', file, file.name);
@@ -250,10 +249,11 @@ const EventForm: React.FC = () => {
       </form>
       <div>
         <ReuploadImageModal
-          title="Last opp arrangementet bilde på nytt"
+          title="Last opp bilde til arrangementet på nytt"
           id={eid}
           shouldOpen={shouldOpen}
           prefix={`/event`}
+          textOnFinish="Arrangementet er opprettet"
           uploadFunction={uploadEventPicture}
         />
         {error && <p>{error}</p>}

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -10,6 +10,7 @@ import {
   emptyFieldsValidator,
   priceValidator,
   maxParticipantsValidator,
+  PNGImageValidator,
 } from 'utils/validators';
 import styles from './eventForm.module.scss';
 import Button from 'components/atoms/button/Button';
@@ -19,10 +20,12 @@ import Textarea from 'components/atoms/textarea/Textarea';
 import ToggleButton from 'components/atoms/toggleButton/ToggleButton';
 import DropdownHeader from 'components/atoms/dropdown/dropdownHeader/DropdownHeader';
 import { useToast } from 'hooks/useToast';
+import Modal from 'components/molecules/modal/Modal';
+import ConfirmationBox from 'components/molecules/confirmationBox/ConfirmationBox';
 import FileSelector from 'components/atoms/fileSelector/FileSelector';
 import ReuploadImageModal from 'components/molecules/modals/reuploadModal/ReuploadModal';
 
-const EventForm: React.FC = () => {
+const EventForm = () => {
   const [file, setFile] = useState<File | undefined>();
   const [eid, setEid] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>(undefined);
@@ -46,12 +49,6 @@ const EventForm: React.FC = () => {
   };
   // allows maxParticipants to be empty
   const optionalKeys = ['maxParticipants'];
-
-  function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
-    if (event.target.files) {
-      setFile(event.target.files[0]);
-    }
-  }
 
   const submit = async () => {
     const emptyFields = emptyFieldsValidator({
@@ -87,10 +84,8 @@ const EventForm: React.FC = () => {
       });
       setEid(resp.eid);
       if (file) {
-        const data = new FormData();
-        data.append('image', file, file.name);
         try {
-          await uploadEventPicture(resp.eid, data);
+          await uploadEventPicture(resp.eid, file);
         } catch (error) {
           setShouldOpen(true);
           addToast({
@@ -242,10 +237,12 @@ const EventForm: React.FC = () => {
             label={'Bindende påmelding'}
             initValue={bindingRegistration}></ToggleButton>
         </div>
-        <div className={styles.imgContainer}>
-          <label>Last opp bilde til arrangementet </label>
-          <input type="file" accept="image/*" onChange={handleFileUpload} />
-        </div>
+        <FileSelector
+          setFile={setFile}
+          text="Last opp bilde til arrangementet"
+          fileValidator={PNGImageValidator}
+          accept="image/png"
+        />
       </form>
       <div>
         <ReuploadImageModal

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -33,6 +33,20 @@
   }
 }
 
+.imgReupload {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  text-align: center;
+
+  input {
+    width: auto;
+    margin-bottom: 1rem;
+  }
+}
+
 .imgContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -47,20 +47,6 @@
   }
 }
 
-.imgContainer {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 1rem;
-  width: 100%;
-  text-align: center;
-
-  input {
-    width: auto;
-  }
-}
-
 .registerheader {
   width: 100%;
 }

--- a/src/components/molecules/forms/jobForm/JobForm.tsx
+++ b/src/components/molecules/forms/jobForm/JobForm.tsx
@@ -23,7 +23,7 @@ import FileSelector from 'components/atoms/fileSelector/FileSelector';
 import { useToast } from 'hooks/useToast';
 import ReuploadImageModal from 'components/molecules/modals/reuploadModal/ReuploadModal';
 
-const JobForm = () => {
+const JobForm: React.FC = () => {
   const [file, setFile] = useState<File | undefined>();
   const [error, setError] = useState<string | undefined>(undefined);
   const [prevData, setPrevData] = useState<JobItem | undefined>(undefined);
@@ -227,6 +227,7 @@ const JobForm = () => {
         id={id}
         shouldOpen={shouldReupload}
         prefix={`/jobs`}
+        textOnFinish="Stillingsutlysningen er opprettet"
         uploadFunction={uploadJobPicture}
       />
       <div>

--- a/src/components/molecules/forms/jobForm/JobForm.tsx
+++ b/src/components/molecules/forms/jobForm/JobForm.tsx
@@ -9,6 +9,7 @@ import {
   JobTypeValidator,
   JobLocationValidator,
   JobTitleValidator,
+  PNGImageValidator,
 } from 'utils/validators';
 import './jobForm.scss';
 import Button from 'components/atoms/button/Button';
@@ -44,12 +45,6 @@ const JobForm: React.FC = () => {
     link: JobLocationValidator,
     type: JobTypeValidator,
   };
-
-  function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
-    if (event.target.files) {
-      setFile(event.target.files[0]);
-    }
-  }
 
   const getJob = () => {
     return {
@@ -233,10 +228,12 @@ const JobForm: React.FC = () => {
       <div>
         <div className={'upload'}>
           {error && <p>{error}</p>}
-          <div className={'imgContainer'}>
-            <label>Last opp bilde til jobben </label>
-            <input type="file" accept="image/*" onChange={handleFileUpload} />
-          </div>
+          <FileSelector
+            setFile={setFile}
+            text="Last opp bilde til stillingsutlysningen"
+            accept="image/png"
+            fileValidator={PNGImageValidator}
+          />
           <Button version={'primary'} onClick={submit}>
             Send
           </Button>

--- a/src/components/molecules/modals/reuploadModal/ReuploadModal.tsx
+++ b/src/components/molecules/modals/reuploadModal/ReuploadModal.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import './reupload.scss';
+import FileSelector from 'components/atoms/fileSelector/FileSelector';
+import ConfirmationBox from 'components/molecules/confirmationBox/ConfirmationBox';
+import Modal from 'components/molecules/modal/Modal';
+import useModal from 'hooks/useModal';
+import { useToast } from 'hooks/useToast';
+import { useHistory } from 'react-router-dom';
+import { PNGImageValidator } from 'utils/validators';
+
+interface IReuploadImageModal {
+  title: string;
+  id: string | undefined;
+  shouldOpen: boolean;
+  prefix: string;
+  textOnFinish: string;
+  uploadFunction: (id: string, file: File) => Promise<void>;
+}
+
+const ReuploadImageModal: React.FC<IReuploadImageModal> = ({
+  title,
+  id,
+  shouldOpen,
+  prefix,
+  textOnFinish,
+  uploadFunction,
+}) => {
+  const [file, setFile] = useState<File | undefined>();
+  const [error, setError] = useState<string | undefined>(undefined);
+  const { addToast } = useToast();
+  const history = useHistory();
+  const { isOpen, onOpen, onClose } = useModal();
+
+  const reuploadImage = async (id: string) => {
+    if (!file) {
+      setError('Bildefil ikke valgt');
+      return;
+    }
+    setError('');
+    try {
+      await uploadFunction(id, file);
+    } catch (error) {
+      addToast({
+        title: 'Feil ved opplasting av bilde',
+        status: 'error',
+        description: 'prøv på nytt',
+      });
+      return;
+    }
+    redirAndDisplayFeedback();
+  };
+
+  const redirAndDisplayFeedback = () => {
+    // give feedback that the "type" is created as the form feedback will not be displayed
+    // since we redirect from this component
+    addToast({
+      title: 'Suksess',
+      status: 'success',
+      description: `${textOnFinish}`,
+    });
+    history.push(`${prefix}/${id}`);
+  };
+
+  useEffect(() => {
+    if (shouldOpen) {
+      onOpen();
+    }
+  }, [shouldOpen]);
+
+  useEffect(() => {
+    if (!isOpen && id !== undefined) {
+      // display feedback on close. has to ensure that id is defined so it does not
+      // trigger before being displayed
+      redirAndDisplayFeedback();
+      return;
+    }
+  }, [isOpen]);
+
+  return (
+    <Modal title={title} isOpen={isOpen} onClose={onClose}>
+      {id !== undefined && (
+        <div className="imgReupload">
+          <FileSelector
+            setFile={setFile}
+            text="En feil skjedde ved opplasting av bilde, prøv på nytt her."
+            accept="image/png"
+            fileValidator={PNGImageValidator}
+          />
+          <ConfirmationBox
+            confirmText="Last opp på nytt"
+            declineText="Opprett uten bilde"
+            onAccept={() => {
+              reuploadImage(id);
+            }}
+            onDecline={() => {
+              onClose();
+              redirAndDisplayFeedback();
+            }}
+          />
+          {error && <p>{error}</p>}
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default ReuploadImageModal;

--- a/src/components/molecules/modals/reuploadModal/reupload.scss
+++ b/src/components/molecules/modals/reuploadModal/reupload.scss
@@ -1,0 +1,13 @@
+.imgReupload {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  text-align: center;
+
+  input {
+    width: auto;
+    margin-bottom: 1rem;
+  }
+}

--- a/src/components/pages/events/eventPage/validEvent/ValidEvent.tsx
+++ b/src/components/pages/events/eventPage/validEvent/ValidEvent.tsx
@@ -10,6 +10,7 @@ import EventHeader from 'components/molecules/event/eventHeader/EventHeader';
 import Button from 'components/atoms/button/Button';
 import Icon from 'components/atoms/icons/icon';
 import { useHistory } from 'react-router-dom';
+import useTitle from 'hooks/useTitle';
 
 export interface EventPageProps {
   eid: string;
@@ -17,6 +18,7 @@ export interface EventPageProps {
 }
 
 const ValidEventLayout: React.FC<{ event: Event }> = ({ event }) => {
+  useTitle(event.title);
   const { role } = useContext(AuthenticateContext);
   const history = useHistory();
 

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -176,3 +176,7 @@ export const JobLocationValidator = (description: string) => {
 export const JobTitleValidator = (title: string) => {
   return title.length >= 50 ? ['Tittel er for lang'] : undefined;
 };
+
+export const PNGImageValidator = (file: File) => {
+  return file.type !== 'image/png' ? 'Kun PNG filer er støttet' : undefined;
+};


### PR DESCRIPTION
## :goal_net:  Better handling errors on image uploads
  - Resolves #153 
  - Gives users a new opportunity to reupload image if the upload failed
![image](https://user-images.githubusercontent.com/43537864/230766607-aa2ad04b-1eac-422a-9093-40dae057a35b.png)
### :sparkles: FileSelector
  - component to handle all file selection on the website  
![image](https://user-images.githubusercontent.com/43537864/230766075-be6bb76c-5383-4d98-a9c4-5c25244950ec.png)
   - An validator can be provided, which is enforced by the component