### PR TITLE
:bug: force typescript version to patch-versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "sass": "^1.55.0",
-    "typescript": "^4.3.5",
+    "typescript": "~4.3.5",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11610,10 +11610,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.3.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Problem

The workflow to build failed after the latest PR. I have no idea why, but it seems to be because of some mismatch with typescript version.

# Solution

Force typescript version to a specific version with patch releases, and avoid minor releases: https://docs.npmjs.com/about-semantic-versioning


# Ideal solution for future

Should ideally update the code to support a newer typescript version, but that takes a lot of time and could be for the future as quite a few changes are needed in regards to error handling