### PR TITLE
:lipstick: Improve event view on mobile

### DIFF
--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -158,14 +158,12 @@ input[type='time']::-webkit-calendar-picker-indicator {
   }
   .descriptionContainer {
     padding: 0px;
-    text-align: center;
   }
 
   .description {
     width: 100%;
     display: flex;
     justify-content: center;
-    text-align: center;
   }
 }
 

--- a/src/components/pages/events/eventPage/eventPage.module.scss
+++ b/src/components/pages/events/eventPage/eventPage.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   height: 100%;
   width: 100%;
-  // background-color: black;
   justify-content: center;
   align-items: center;
 }
@@ -15,4 +14,10 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+@media screen and (max-width: 768px) {
+  .eventContainer {
+    width: 95vw;
+  }
 }

--- a/src/components/pages/events/eventPage/validEvent/validEvent.module.scss
+++ b/src/components/pages/events/eventPage/validEvent/validEvent.module.scss
@@ -28,3 +28,9 @@
   width: 100%;
   display: flex;
 }
+
+@media screen and (max-width: 768px) {
+  .header {
+    max-width: 95vw;
+  }
+}


### PR DESCRIPTION
# :gem: Improved mobile view for events
The following changes have been made to scss affecting devices with narrow screens:

- Margin left and right was reduced
- Description text is now always aligned right (not centered)

:camera: Before and after:
![Screenshot from 2023-04-27 15-07-07](https://user-images.githubusercontent.com/73795796/234881489-ffadeafb-85fe-4d77-91ff-50cc9f375311.png)

![image](https://user-images.githubusercontent.com/73795796/235152124-03574b4c-cda9-4040-8284-ec61c7fa5b80.png)

