### PR TITLE
:bug: fix event statistics when maxParticipants is undefined

### DIFF
--- a/src/components/molecules/event/eventStatistics/EventStatistics.tsx
+++ b/src/components/molecules/event/eventStatistics/EventStatistics.tsx
@@ -368,7 +368,9 @@ const EventStatistics: React.FC<{
     const parts = event.participants?.sort((a, b) =>
       sortString(a.submitDate, b.submitDate)
     );
-    setParticipants(parts?.slice(0, event.maxParticipants) || []);
+    setParticipants(
+      parts?.slice(0, event.maxParticipants ?? event.participants?.length) || []
+    );
   };
 
   useEffect(() => {


### PR DESCRIPTION
### :bug: Fixes event statistics assuming maxParticipants is defined
 - fixes #194 