### PR TITLE
Fix/event public toggle and registration date

### DIFF
--- a/src/components/molecules/event/eventBody/EventBody.tsx
+++ b/src/components/molecules/event/eventBody/EventBody.tsx
@@ -6,6 +6,7 @@ import TextField from 'components/atoms/textfield/Textfield';
 import Textarea from 'components/atoms/textarea/Textarea';
 import { Button } from '@chakra-ui/react';
 import ToggleButton from 'components/atoms/toggleButton/ToggleButton';
+import { Text } from '@chakra-ui/react';
 import { getJoinedParticipants, updateEvent, uploadEventPicture } from 'api';
 import {
   addressValidator,
@@ -263,9 +264,15 @@ export const EditEvent: React.FC<{ event: Event; setEdit: () => void }> = ({
                   <ToggleButton
                     initValue={togglePublic}
                     onChange={() => setTogglePublic(!togglePublic)}
-                    label={
-                      togglePublic ? 'Offentlig' : 'Privat'
-                    }></ToggleButton>
+                    label={'Offentlig'}></ToggleButton>
+                  {!togglePublic && (
+                    <Text
+                      fontSize="0.75rem"
+                      color="red.500"
+                      style={{ fontStyle: 'italic' }}>
+                      Arrangementet vil ikke være synlig for andre enn admin
+                    </Text>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/molecules/event/eventBody/EventBody.tsx
+++ b/src/components/molecules/event/eventBody/EventBody.tsx
@@ -115,6 +115,13 @@ export const EditEvent: React.FC<{ event: Event; setEdit: () => void }> = ({
         await uploadEventPicture(event.eid, file);
       }
     } catch (error) {
+      if (error.statusCode === 413) {
+        addToast({
+          title: 'Bildet er for stort',
+          status: 'error',
+        });
+        return;
+      }
       addToast({
         title: 'Feil ved opplasting av bilde',
         status: 'error',

--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -83,8 +83,6 @@
     font-weight: bold;
     padding: 0px;
     margin: 0px;
-    font-size: 1rem;
-    // line-height: 0.1rem;
   }
   button {
     width: 80%;

--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -48,7 +48,7 @@
     margin-top: 0.5rem;
   }
   textarea {
-    height: 15vh;
+    height: 35vh;
     overflow: auto;
   }
 }

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -87,6 +87,13 @@ const EventForm = () => {
           await uploadEventPicture(resp.eid, file);
         } catch (error) {
           setShouldOpen(true);
+          if (error.statusCode === 413) {
+            addToast({
+              title: 'Bildet er for stort',
+              status: 'error',
+            });
+            return;
+          }
           addToast({
             title: 'Feil ved opplasting av bilde',
             status: 'error',

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -12,6 +12,7 @@ import {
   PNGImageValidator,
   eventTitleValidator,
 } from 'utils/validators';
+import { Text } from '@chakra-ui/react';
 import styles from './eventForm.module.scss';
 import { Button } from '@chakra-ui/react';
 import { createEvent, uploadEventPicture } from 'api';
@@ -226,7 +227,7 @@ const EventForm = () => {
             onChange={() => {
               setPublicEvent(!publicEvent);
             }}
-            label={'Skal arrangementet være synlig for vanlige brukere'}
+            label={'Offentlig (synlig for vanlige brukere)'}
             initValue={publicEvent}></ToggleButton>
           <ToggleButton
             onChange={() => {
@@ -252,6 +253,14 @@ const EventForm = () => {
           uploadFunction={uploadEventPicture}
         />
         {error && <p>{error}</p>}
+        {!publicEvent && (
+          <Text
+            fontSize="0.75rem"
+            color="red.500"
+            style={{ fontStyle: 'italic' }}>
+            MERK: Arrangementet vil ikke være synlig for andre enn admin
+          </Text>
+        )}
         <Button variant={'primary'} onClick={submit}>
           Submit
         </Button>

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -78,9 +78,11 @@ input[type='time']::-webkit-calendar-picker-indicator {
   justify-content: flex-start;
   flex-direction: column;
   width: 100%;
+  gap: .5rem;
 
   p {
     line-height: 0.5;
+    margin: 0;
   }
 }
 

--- a/src/components/pages/events/eventPage/EventPage.tsx
+++ b/src/components/pages/events/eventPage/EventPage.tsx
@@ -5,6 +5,7 @@ import ValidEventLayout from './validEvent/ValidEvent';
 import { getEventById } from 'api';
 import styles from './eventPage.module.scss';
 import { AuthenticateContext, Roles } from 'contexts/authProvider';
+import Footer from 'components/molecules/footer/Footer';
 
 export interface IValidEventLayout {
   eventData: Event | undefined;
@@ -57,6 +58,7 @@ const EventPage = () => {
           </div>
         </div>
       )}
+      <Footer />
     </div>
   );
 };

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -15,6 +15,7 @@ import useTitle from 'hooks/useTitle';
 import useModal from 'hooks/useModal';
 import ReactMarkdown from 'react-markdown';
 import LoadingWrapper from 'components/atoms/loadingWrapper/LoadingWrapper';
+import Footer from 'components/molecules/footer/Footer';
 
 interface IValidJob {
   jobData: JobItem | undefined;
@@ -28,6 +29,7 @@ export const ValidJob: React.FC<IValidJob> = ({ jobData }) => {
       ) : (
         <p> 404 job not found!</p>
       )}
+      <Footer />
     </div>
   );
 };
@@ -193,7 +195,7 @@ const Job = () => {
 
   return (
     <LoadingWrapper data={data} startAfter={250}>
-      <ValidJob jobData={data}></ValidJob>;
+      <ValidJob jobData={data}></ValidJob>
     </LoadingWrapper>
   );
 };

--- a/src/components/pages/jobs/Jobs.tsx
+++ b/src/components/pages/jobs/Jobs.tsx
@@ -14,6 +14,7 @@ import JobCard from 'components/molecules/jobCard/JobCard';
 import useTitle from 'hooks/useTitle';
 import useModal from 'hooks/useModal';
 import Modal from 'components/molecules/modal/Modal';
+import Footer from 'components/molecules/footer/Footer';
 
 interface ChipProps {
   label: string;
@@ -204,6 +205,7 @@ const JobList: React.FC = () => {
           </div>
         </div>
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -140,6 +140,16 @@ export const timeValidator = (time: string) => {
   return time.length ? undefined : ['Tidspunkt må fylles ut'];
 };
 
+/* Empty validators for optional date/time for now */
+/* TODO: find better solution for optional validation */
+export const notRequiredDateValidator = (date: string) => {
+  return undefined;
+};
+
+export const notRequiredTimeValidator = (time: string) => {
+  return undefined;
+};
+
 // description length constraint
 export const descriptionValidator = (description: string) => {
   return description.length


### PR DESCRIPTION
# :gem: Fix UI for toggling event public/private and edit registration opening date

## :sparkles: Fixed public toggle for event
- Toggle label now makes sense and doesn't change on toggle in event edit view
- Warning is added to signify private event

:camera: Event edit view
![Screenshot from 2023-08-10 22-35-06](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/bf039128-873c-48f3-a6cf-7da9e61070f6)

:camera: Event create view
![Screenshot from 2023-08-10 22-35-56](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/00a44492-2d53-4be0-bdb9-c9bae0f39584)

## :sparkles: Added ability for admin to edit registration opening date
:camera: New text fields in event edit view:
![Screenshot from 2023-08-10 22-35-32](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/b3931138-8cf3-4cd0-828d-83d190d18931)

:camera: Also added information for admin in normal event view
![Screenshot from 2023-08-10 22-44-18](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/8ad0f6bb-6af1-4b99-b865-6fd007b4070e)

## :children_crossing: Added modal response for too large image
Modal will now specify that the image was too large if it receives error code `413`

## :lipstick: Added footer to additional pages
- `/event/{id}`
- `/jobs`
- `/jobs/{id}`
