### PR TITLE
fix/create-job

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   ResetPasswordPage,
   Jobs,
   Job,
+  CreateJob,
   AboutPage,
   NewStudentsPage,
 } from 'components/pages';
@@ -50,6 +51,7 @@ const App: React.FC = () => {
           />
           <Route path="/jobs/:id" component={Job} />
           <Route path="/jobs" component={Jobs} />
+          <AdminRoute path="/create-job" component={CreateJob} />
           <Route
             path="/confirmation/:confirmationCode"
             children={<ConfirmationPage />}

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -17,6 +17,7 @@ import NewStudentsPage from './newStudent/NewStudent';
 
 import Jobs from './jobs/Jobs';
 import Job from './jobs/Job';
+import CreateJob from './jobs/CreateJob';
 export {
   RegistrerPage,
   HomePage,
@@ -34,6 +35,7 @@ export {
   ResetPasswordPage,
   Jobs,
   Job,
+  CreateJob,
   AboutPage,
   NewStudentsPage,
 };

--- a/src/components/pages/jobs/CreateJob.tsx
+++ b/src/components/pages/jobs/CreateJob.tsx
@@ -1,0 +1,15 @@
+import { Center, Heading, VStack } from '@chakra-ui/react';
+import JobForm from 'components/molecules/forms/jobForm/JobForm';
+
+const CreateJob = () => {
+  return (
+    <Center mt="2rem">
+      <VStack>
+        <Heading>Opprett Stillingsutlysning</Heading>
+        <JobForm />
+      </VStack>
+    </Center>
+  );
+};
+
+export default CreateJob;

--- a/src/components/pages/jobs/Jobs.tsx
+++ b/src/components/pages/jobs/Jobs.tsx
@@ -6,15 +6,13 @@ import { JobItem } from 'models/apiModels';
 import TextField from 'components/atoms/textfield/Textfield';
 import { getJobs } from 'api/jobs';
 import { AuthenticateContext, Roles } from 'contexts/authProvider';
-import JobForm from 'components/molecules/forms/jobForm/JobForm';
 import JobFilterProvider, {
   FilterContextHook,
 } from 'contexts/filterJobProvider';
 import JobCard from 'components/molecules/jobCard/JobCard';
 import useTitle from 'hooks/useTitle';
-import useModal from 'hooks/useModal';
-import Modal from 'components/molecules/modal/Modal';
 import Footer from 'components/molecules/footer/Footer';
+import { useHistory } from 'react-router-dom';
 
 interface ChipProps {
   label: string;
@@ -158,7 +156,11 @@ const FilterJobs: React.FC = () => {
 const JobList: React.FC = () => {
   const { role } = useContext(AuthenticateContext);
   const { context, setContext } = useContext(FilterContextHook);
-  const { isOpen, onOpen, onClose } = useModal();
+  const history = useHistory();
+
+  const goToCreate = () => {
+    history.push('/create-job');
+  };
 
   useEffect(() => {
     const fetchJobs = async () => {
@@ -183,7 +185,7 @@ const JobList: React.FC = () => {
               type={'plus'}
               size={2}
               color={'rgba(240, 150, 103, 0.3)'}
-              onClick={onOpen}></Icon>
+              onClick={goToCreate}></Icon>
           )}
         </div>
 
@@ -191,11 +193,6 @@ const JobList: React.FC = () => {
           <FilterJobs />
 
           <div className={styles.mainContent}>
-            <Modal title="Lag ny utlysning" isOpen={isOpen} onClose={onClose}>
-              <div className={styles.jobsFormContainer}>
-                <JobForm />
-              </div>
-            </Modal>
             {context.allJobs?.length === 0 && (
               <h5>Ingen stillingsutlysninger</h5>
             )}

--- a/src/components/pages/jobs/jobs.module.scss
+++ b/src/components/pages/jobs/jobs.module.scss
@@ -52,11 +52,6 @@
   color: rgba(240, 150, 103, 0.5);
   cursor: pointer;
 }
-.jobsFormContainer {
-  display: flex;
-  justify-content: center;
-  min-width: 65vw;
-}
 
 .filterWrapper {
   display: flex;


### PR DESCRIPTION
# :bug: Moved create job form to its own page to avoid cutoff

The create job form was too large for the modal it was originally on, meaning content was cut off and the form was unusable.

:camera: This picture shows the full height of the view. This modal is not scrollable.

![Screenshot from 2023-08-24 10-54-46](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/df4b370b-f94a-44ab-b576-df861e810dd9)

The form was instead moved to its own page, allowing the content to be scrollable and fit any content height.

:camera: This page is scrollable.

![Screenshot from 2023-08-24 10-55-09](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/e52f390f-e38c-4ff0-a509-1b28e82e464c)

