### PR TITLE
Feature/edit jobs

### DIFF
--- a/src/api/jobs.ts
+++ b/src/api/jobs.ts
@@ -1,6 +1,6 @@
-import { JobItem, CreateJob } from 'models/apiModels';
+import { JobItem, CreateJob, JobUpdate } from 'models/apiModels';
 
-import { get, post, Delete } from './requests';
+import { get, post, put, Delete } from './requests';
 
 export const getJobs = (): Promise<JobItem[]> => get<JobItem[]>('jobs/');
 
@@ -21,3 +21,8 @@ export const getJobImage = (id: string): Promise<{ image: any }> =>
 
 export const deleteJob = (id: string): Promise<{ id: string }> =>
   Delete<{ id: string }>('jobs/' + id);
+
+export const updateJob = (
+  id: string,
+  job: JobUpdate
+): Promise<{ id: string }> => put<{ id: string }>('jobs/' + id, job);

--- a/src/components/molecules/forms/jobForm/JobForm.tsx
+++ b/src/components/molecules/forms/jobForm/JobForm.tsx
@@ -308,7 +308,7 @@ const JobForm: React.FC<IJobform> = ({ job }) => {
             overflowX: 'hidden',
             overflowY: 'auto',
           }}>
-          <ValidJob jobData={prevData} />
+          <ValidJob jobData={prevData} isPreview />
         </div>
       </Modal>
       <ReuploadImageModal

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -20,13 +20,14 @@ import JobForm from 'components/molecules/forms/jobForm/JobForm';
 
 interface IValidJob {
   jobData: JobItem | undefined;
+  isPreview?: boolean;
 }
 
-export const ValidJob: React.FC<IValidJob> = ({ jobData }) => {
+export const ValidJob: React.FC<IValidJob> = ({ jobData, isPreview }) => {
   return (
     <div>
       {jobData !== undefined ? (
-        <ValidJobLayout jobData={jobData} />
+        <ValidJobLayout jobData={jobData} isPreview={isPreview} />
       ) : (
         <p> 404 job not found!</p>
       )}
@@ -35,7 +36,12 @@ export const ValidJob: React.FC<IValidJob> = ({ jobData }) => {
   );
 };
 
-const ValidJobLayout: React.FC<{ jobData: JobItem }> = ({ jobData }) => {
+interface IValidJobLayout {
+  jobData: JobItem;
+  isPreview?: boolean;
+}
+
+const ValidJobLayout: React.FC<IValidJobLayout> = ({ jobData, isPreview }) => {
   useTitle(`${jobData.title}`);
   const isMobile = useMobileScreen();
   const { addToast } = useToast();
@@ -67,17 +73,15 @@ const ValidJobLayout: React.FC<{ jobData: JobItem }> = ({ jobData }) => {
                       style={{
                         marginBottom: '2rem',
                       }}>
-                      <Icon
-                        type="arrow-left"
-                        size={2}
-                        color=" rgba(240, 150, 103, 0.3)"
-                        onClick={() => {
-                          // id undefined means in preview mode
-                          if (id === undefined) {
-                            return;
-                          }
-                          history.goBack();
-                        }}></Icon>
+                      {!isPreview && (
+                        <Icon
+                          type="arrow-left"
+                          size={2}
+                          color=" rgba(240, 150, 103, 0.3)"
+                          onClick={() => {
+                            history.goBack();
+                          }}></Icon>
+                      )}
                     </div>
                   )}
                   <div className={'logoWrapper'}>
@@ -93,7 +97,7 @@ const ValidJobLayout: React.FC<{ jobData: JobItem }> = ({ jobData }) => {
                   </div>
                   <hr />
                   <div>
-                    Ansettelsform: <br /> <small>{jobData.type}</small>
+                    Ansettelsesform: <br /> <small>{jobData.type}</small>
                   </div>
                   <hr />
                   <div>
@@ -132,23 +136,25 @@ const ValidJobLayout: React.FC<{ jobData: JobItem }> = ({ jobData }) => {
                     </small>
                   </div>
                   <hr />
-                  <a href={jobData.link} style={{ textDecoration: 'none' }}>
-                    <div className={'applyButton'}>
-                      Søk her!
-                      <Icon type={''} size={1.5} color={'#f09667'}></Icon>
-                    </div>
-                  </a>
-                  {role === Roles.admin && (
+                  <Button
+                    as={Link}
+                    href={jobData.link}
+                    isExternal
+                    mt="2rem"
+                    color="white"
+                    textDecoration="none">
+                    Søk her!
+                  </Button>
+                  {role === Roles.admin && !isPreview && (
                     <>
-                      <div className={'applyButton'} onClick={onOpen}>
+                      <Button onClick={onOpen} mt="3rem" variant="secondary">
                         Slett
-                        <Icon
-                          type={'trash'}
-                          size={1.2}
-                          color={'#f09667'}></Icon>
-                      </div>
-                      <Button onClick={() => setIsEditing(true)} mt="1rem">
-                        rediger
+                      </Button>
+                      <Button
+                        onClick={() => setIsEditing(true)}
+                        mt="1rem"
+                        variant="secondary">
+                        Rediger
                       </Button>
                     </>
                   )}

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -127,15 +127,6 @@ const ValidJobLayout: React.FC<IValidJobLayout> = ({ jobData, isPreview }) => {
                     </small>
                   </div>
                   <hr />
-                  <div>
-                    Hjemmeside <br />
-                    <small>
-                      <a href={jobData.link} style={{ textDecoration: 'none' }}>
-                        <div style={{ color: '#f09667' }}>{jobData.link}</div>
-                      </a>
-                    </small>
-                  </div>
-                  <hr />
                   <Button
                     as={Link}
                     href={jobData.link}

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import './job.scss';
 import { JobItem } from 'models/apiModels';
@@ -10,12 +10,13 @@ import Modal from 'components/molecules/modal/Modal';
 import { useMobileScreen } from 'hooks/useMobileScreen';
 import { useHistory } from 'react-router-dom';
 import { useToast } from 'hooks/useToast';
-import { Button } from '@chakra-ui/react';
+import { Button, Center, Heading, Link, VStack } from '@chakra-ui/react';
 import useTitle from 'hooks/useTitle';
 import useModal from 'hooks/useModal';
 import ReactMarkdown from 'react-markdown';
 import LoadingWrapper from 'components/atoms/loadingWrapper/LoadingWrapper';
 import Footer from 'components/molecules/footer/Footer';
+import JobForm from 'components/molecules/forms/jobForm/JobForm';
 
 interface IValidJob {
   jobData: JobItem | undefined;
@@ -42,137 +43,159 @@ const ValidJobLayout: React.FC<{ jobData: JobItem }> = ({ jobData }) => {
   const { role } = useContext(AuthenticateContext);
   const history = useHistory();
   const imgUrl = baseUrl + 'jobs/' + jobData?.id + '/image';
+  const [isEditing, setIsEditing] = useState<boolean>(false);
 
   const { isOpen, onOpen, onClose } = useModal();
 
   return (
     <div>
-      <div className={'pageWrapper'}>
-        <div>
-          <div className={'content'}>
-            <div className={'sidebar'}>
-              {!isMobile && (
-                <div
-                  style={{
-                    marginBottom: '2rem',
-                  }}>
-                  <Icon
-                    type="arrow-left"
-                    size={2}
-                    color=" rgba(240, 150, 103, 0.3)"
-                    onClick={() => {
-                      // id undefined means in preview mode
-                      if (id === undefined) {
-                        return;
-                      }
-                      history.goBack();
-                    }}></Icon>
-                </div>
-              )}
-              <div className={'logoWrapper'}>
-                <img
-                  src={imgUrl}
-                  alt=""
-                  className={'logo'}
-                  onError={({ currentTarget }) => {
-                    currentTarget.onerror = null; // prevents looping
-                    currentTarget.src = 'https://img.logoipsum.com/295.svg';
-                  }}
-                />
-              </div>
-              <hr />
-              <div>
-                Ansettelsform: <br /> <small>{jobData.type}</small>
-              </div>
-              <hr />
-              <div>
-                Firma: <br /> <small>{jobData.company}</small>
-              </div>
-              <hr />
-              <div>
-                Sted: <br /> <small>{jobData.location}</small>
-              </div>
-              <hr />
-              {jobData?.start_date != null && (
-                <div>
-                  Start dato
-                  <br />
-                  <small>{new Date(jobData?.start_date).toDateString()}</small>
-                  <hr />
-                </div>
-              )}
-              <div>
-                Søknadsfrist <br />
-                <small>
-                  {jobData.due_date != null
-                    ? new Date(jobData.due_date).toDateString()
-                    : 'Fortløpende'}
-                </small>
-              </div>
-              <hr />
-              <div>
-                Hjemmeside <br />
-                <small>
-                  <a href={jobData.link} style={{ textDecoration: 'none' }}>
-                    <div style={{ color: '#f09667' }}>{jobData.link}</div>
-                  </a>
-                </small>
-              </div>
-              <hr />
-              <a href={jobData.link} style={{ textDecoration: 'none' }}>
-                <div className={'applyButton'}>
-                  Søk her!
-                  <Icon type={''} size={1.5} color={'#f09667'}></Icon>
-                </div>
-              </a>
-              {role === Roles.admin && (
-                <div className={'applyButton'} onClick={onOpen}>
-                  Slett
-                  <Icon type={'trash'} size={1.2} color={'#f09667'}></Icon>
-                </div>
-              )}
-            </div>
-            <div className={'main_content'}>
-              <div>
-                <h3>{jobData.title}</h3>
-                <hr />
-              </div>
-              <ReactMarkdown children={jobData.description} />
-              <div className={'tags_container'}>
-                {jobData?.tags?.map((tag, key) => (
-                  <div className={'tags'} key={key}>
-                    {tag}
+      {isEditing ? (
+        <Center mt="2rem">
+          <VStack>
+            <Heading>Rediger Stillingsutlysning</Heading>
+            <JobForm job={jobData} />
+          </VStack>
+        </Center>
+      ) : (
+        <>
+          <div className={'pageWrapper'}>
+            <div>
+              <div className={'content'}>
+                <div className={'sidebar'}>
+                  {!isMobile && (
+                    <div
+                      style={{
+                        marginBottom: '2rem',
+                      }}>
+                      <Icon
+                        type="arrow-left"
+                        size={2}
+                        color=" rgba(240, 150, 103, 0.3)"
+                        onClick={() => {
+                          // id undefined means in preview mode
+                          if (id === undefined) {
+                            return;
+                          }
+                          history.goBack();
+                        }}></Icon>
+                    </div>
+                  )}
+                  <div className={'logoWrapper'}>
+                    <img
+                      src={imgUrl}
+                      alt=""
+                      className={'logo'}
+                      onError={({ currentTarget }) => {
+                        currentTarget.onerror = null; // prevents looping
+                        currentTarget.src = 'https://img.logoipsum.com/295.svg';
+                      }}
+                    />
                   </div>
-                ))}
+                  <hr />
+                  <div>
+                    Ansettelsform: <br /> <small>{jobData.type}</small>
+                  </div>
+                  <hr />
+                  <div>
+                    Firma: <br /> <small>{jobData.company}</small>
+                  </div>
+                  <hr />
+                  <div>
+                    Sted: <br /> <small>{jobData.location}</small>
+                  </div>
+                  <hr />
+                  {jobData?.start_date != null && (
+                    <div>
+                      Start dato
+                      <br />
+                      <small>
+                        {new Date(jobData?.start_date).toDateString()}
+                      </small>
+                      <hr />
+                    </div>
+                  )}
+                  <div>
+                    Søknadsfrist <br />
+                    <small>
+                      {jobData.due_date != null
+                        ? new Date(jobData.due_date).toDateString()
+                        : 'Fortløpende'}
+                    </small>
+                  </div>
+                  <hr />
+                  <div>
+                    Hjemmeside <br />
+                    <small>
+                      <a href={jobData.link} style={{ textDecoration: 'none' }}>
+                        <div style={{ color: '#f09667' }}>{jobData.link}</div>
+                      </a>
+                    </small>
+                  </div>
+                  <hr />
+                  <a href={jobData.link} style={{ textDecoration: 'none' }}>
+                    <div className={'applyButton'}>
+                      Søk her!
+                      <Icon type={''} size={1.5} color={'#f09667'}></Icon>
+                    </div>
+                  </a>
+                  {role === Roles.admin && (
+                    <>
+                      <div className={'applyButton'} onClick={onOpen}>
+                        Slett
+                        <Icon
+                          type={'trash'}
+                          size={1.2}
+                          color={'#f09667'}></Icon>
+                      </div>
+                      <Button onClick={() => setIsEditing(true)} mt="1rem">
+                        rediger
+                      </Button>
+                    </>
+                  )}
+                </div>
+                <div className={'main_content'}>
+                  <div>
+                    <h3>{jobData.title}</h3>
+                    <hr />
+                  </div>
+                  <ReactMarkdown children={jobData.description} />
+                  <div className={'tags_container'}>
+                    {jobData?.tags?.map((tag, key) => (
+                      <div className={'tags'} key={key}>
+                        {tag}
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
-      <Modal
-        title={'Delete ' + String(jobData?.title)}
-        isOpen={isOpen}
-        onClose={onClose}>
-        <div className={'deleteModal'}>
-          <h5>Er du sikker på at du vil slette utlysningen?</h5>
-          <Button
-            variant="primary"
-            onClick={() => {
-              deleteJob(id);
-              history.goBack();
-              addToast({
-                title: 'Job: ' + jobData?.id + ' deleted',
-                status: 'success',
-              });
-            }}>
-            Slett
-          </Button>
+          <Modal
+            title={'Delete ' + String(jobData?.title)}
+            isOpen={isOpen}
+            onClose={onClose}>
+            <div className={'deleteModal'}>
+              <h5>Er du sikker på at du vil slette utlysningen?</h5>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  deleteJob(id);
+                  history.goBack();
+                  addToast({
+                    title: 'Job: ' + jobData?.id + ' deleted',
+                    status: 'success',
+                  });
+                }}>
+                Slett
+              </Button>
 
-          <p onClick={onClose} style={{ cursor: 'pointer' }}>
-            Tilbake
-          </p>
-        </div>
-      </Modal>
+              <p onClick={onClose} style={{ cursor: 'pointer' }}>
+                Tilbake
+              </p>
+            </div>
+          </Modal>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -155,7 +155,10 @@ const ValidJobLayout: React.FC<IValidJobLayout> = ({ jobData, isPreview }) => {
                     <h3>{jobData.title}</h3>
                     <hr />
                   </div>
-                  <ReactMarkdown children={jobData.description} />
+                  <ReactMarkdown
+                    children={jobData.description}
+                    className="markdown"
+                  />
                   <div className={'tags_container'}>
                     {jobData?.tags?.map((tag, key) => (
                       <div className={'tags'} key={key}>

--- a/src/components/pages/jobs/job.scss
+++ b/src/components/pages/jobs/job.scss
@@ -81,6 +81,14 @@
   padding: 3rem;
 }
 
+.markdown a {
+  color: #f09667;
+}
+
+.markdown a:hover {
+  text-decoration: underline;
+}
+
 @media screen and (max-width: 768px) {
   .content {
     flex-direction: column;

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -36,10 +36,16 @@ const constructInitialValues = (
   if (initalValue) {
     Object.keys(initalValue).forEach((key) => {
       const value = initalValue[key];
-      const fieldError = validators?.[key](value) ?? undefined;
+      /* Only return error if validator exists on field */
+      const fieldError = () => {
+        if (validators && validators.hasOwnProperty(key)) {
+          return validators?.[key](value);
+        }
+        return undefined;
+      };
       initialFields[key] = {
         value: initalValue[key],
-        error: fieldError,
+        error: fieldError(),
       };
     });
   }

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -140,3 +140,20 @@ export interface TokenInfo {
 }
 
 export type CreateJob = Omit<JobItem, 'id'>;
+
+export type JobUpdate = Partial<
+  Pick<
+    JobItem,
+    | 'company'
+    | 'title'
+    | 'type'
+    | 'tags'
+    | 'description_preview'
+    | 'description'
+    | 'published_date'
+    | 'location'
+    | 'link'
+    | 'start_date'
+    | 'due_date'
+  >
+>;


### PR DESCRIPTION
# :gem: Add edit button to jobs

:sparkles: Admin now has the ability to edit jobs instead of having to delete and recreate them. Edit interface is identical to job creation interface.

![image](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/695638d7-d332-4607-93fd-3e51e43717f1)

:lipstick: Links in the markdown text area on jobs now have colored links, underlined on hover. They were simply white with no text decoration previously.

:fire: The 'Homepage' section on the job page was removed, as it was simply a redundant link with the same target as the 'Søk nå!' button.
