### PR TITLE
:adhesive_bandage: Sort jobs by due date

### DIFF
--- a/src/contexts/filterJobProvider.tsx
+++ b/src/contexts/filterJobProvider.tsx
@@ -70,11 +70,25 @@ const JobFilterProvider: React.FC<IJobFilterProvider> = ({ children }) => {
             });
       // Sorts the jobs by date
       let sorted = tagFilter.sort(function (a, b) {
-        return filterContext.sort_date
-          ? new Date(b.published_date).getTime() -
-              new Date(a.published_date).getTime()
-          : new Date(a.published_date).getTime() -
-              new Date(b.published_date).getTime();
+        if (filterContext.sort_date) {
+          /* Jobs with no due date pushed to bottom */
+          if (a.due_date === undefined) {
+            return -1;
+          }
+          if (b.due_date === undefined) {
+            return 1;
+          }
+          return a.due_date < b.due_date ? -1 : 1;
+        } else {
+          /* Jobs with no due date pushed to top */
+          if (a.due_date === undefined) {
+            return 1;
+          }
+          if (b.due_date === undefined) {
+            return -1;
+          }
+          return a.due_date < b.due_date ? 1 : -1;
+        }
       });
       return sorted;
     };


### PR DESCRIPTION
# :gem: Hotfix to sort jobs by due date instead of published date

The jobs with the first pending due dates should be shown at the top of the jobs list by default