### PR TITLE
Feature/store user traffic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,15 +20,20 @@ import {
   CreateJob,
   AboutPage,
   NewStudentsPage,
+  StatsPage,
 } from 'components/pages';
 import { PrivateRoute, AuthorizationRoute, AdminRoute } from 'routes';
 import Navbar from 'components/molecules/navbar/Navbar';
 import ToastProvider from 'contexts/toastProvider';
+import AnalyticsProvider from 'contexts/analyticsProvider';
 
 const App: React.FC = () => {
+  // parent path to track visits
+  const monitorPaths = ['jobs', 'event'];
   return (
     <Router>
       <ToastProvider>
+        <AnalyticsProvider paths={monitorPaths}>
         <Navbar />
         <Switch>
           <AuthorizationRoute path="/registrer" component={RegistrerPage} />
@@ -60,6 +65,7 @@ const App: React.FC = () => {
           <Route path="/new-student" component={NewStudentsPage} />
           <Route path="/" component={HomePage} />
         </Switch>
+      </AnalyticsProvider>
       </ToastProvider>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,38 +34,39 @@ const App: React.FC = () => {
     <Router>
       <ToastProvider>
         <AnalyticsProvider paths={monitorPaths}>
-        <Navbar />
-        <Switch>
-          <AuthorizationRoute path="/registrer" component={RegistrerPage} />
-          <AuthorizationRoute path="/login" component={LoginPage} />
-          <PrivateRoute path="/profile" component={ProfilePage} />
-          <PrivateRoute path="/eventoverview" component={EventOverview} />
-          <AdminRoute path="/create-event" component={CreateEvent} />
-          <AdminRoute path="/admin" component={AdminPage} />
-          <AdminRoute path="/event/:id/admin" component={EventAdmin} />
-          <Route path="/event/:rid/register" component={EventRegisterPage} />
-          <Route path="/event/:id" children={<EventPage />} />
-          <Route
-            path="/confirmation/:confirmationCode"
-            children={<ConfirmationPage />}
-          />
-          <Route path="/restore-password" component={RestorePasswordPage} />
-          <Route
-            path="/reset-password/:resetPasswordCode"
-            component={ResetPasswordPage}
-          />
-          <Route path="/jobs/:id" component={Job} />
-          <Route path="/jobs" component={Jobs} />
-          <AdminRoute path="/create-job" component={CreateJob} />
-          <Route
-            path="/confirmation/:confirmationCode"
-            children={<ConfirmationPage />}
-          />
-          <Route path="/about-us" component={AboutPage} />
-          <Route path="/new-student" component={NewStudentsPage} />
-          <Route path="/" component={HomePage} />
-        </Switch>
-      </AnalyticsProvider>
+          <Navbar />
+          <Switch>
+            <AuthorizationRoute path="/registrer" component={RegistrerPage} />
+            <AuthorizationRoute path="/login" component={LoginPage} />
+            <PrivateRoute path="/profile" component={ProfilePage} />
+            <PrivateRoute path="/eventoverview" component={EventOverview} />
+            <AdminRoute path="/create-event" component={CreateEvent} />
+            <AdminRoute path="/admin" component={AdminPage} />
+            <AdminRoute path="/event/:id/admin" component={EventAdmin} />
+            <AdminRoute path="/stats" component={StatsPage} />
+            <Route path="/event/:rid/register" component={EventRegisterPage} />
+            <Route path="/event/:id" children={<EventPage />} />
+            <Route
+              path="/confirmation/:confirmationCode"
+              children={<ConfirmationPage />}
+            />
+            <Route path="/restore-password" component={RestorePasswordPage} />
+            <Route
+              path="/reset-password/:resetPasswordCode"
+              component={ResetPasswordPage}
+            />
+            <Route path="/jobs/:id" component={Job} />
+            <Route path="/jobs" component={Jobs} />
+            <AdminRoute path="/create-job" component={CreateJob} />
+            <Route
+              path="/confirmation/:confirmationCode"
+              children={<ConfirmationPage />}
+            />
+            <Route path="/about-us" component={AboutPage} />
+            <Route path="/new-student" component={NewStudentsPage} />
+            <Route path="/" component={HomePage} />
+          </Switch>
+        </AnalyticsProvider>
       </ToastProvider>
     </Router>
   );

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,6 @@
 export * from './member';
 export * from './auth';
 export * from './event';
+export * from './stats';
+
 export { get, post, put } from './requests';

--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -22,8 +22,22 @@ export class HttpError extends Error {
   };
 }
 
-export const get = async <T>(url: string) => {
-  const request = new Request(baseUrl + url, {
+interface QueryParams {
+  [key: string]: string;
+}
+
+// parameter adds support for query parameters
+export const get = async <T>(path: string, parameter?: QueryParams) => {
+  let url = baseUrl + path;
+  if (parameter) {
+    const urlObj = new URL(url);
+    const searchParams = urlObj.searchParams;
+    Object.entries(parameter).forEach(([key, value]) => {
+      searchParams.set(key, value);
+    });
+    url = urlObj.href;
+  }
+  const request = new Request(url, {
     credentials: 'include',
     headers: {
       accept: 'application/json, application/pdf',

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,0 +1,22 @@
+import { IPageStats, IPageVisit, IVisits } from 'models/apiModels';
+import { get, post } from './requests';
+
+export const postUniqueVisit = (): Promise<{}> =>
+  post<{}>('stats/unique-visit', {});
+
+export const getUniqueVisits = (
+  start?: string,
+  end?: string
+): Promise<IVisits[]> => {
+  return get<IVisits[]>('stats/unique-visit', {
+    ...(start && { start: start }),
+    // endpoint uses datenow if end is not specified
+    ...(end && { end: end }),
+  });
+};
+
+export const logVisit = (payload: IPageVisit): Promise<{}> =>
+  post<{}>('stats/page-visit', payload);
+
+export const getPageVisitsLastMonth = (): Promise<IPageStats[]> =>
+  get<IPageStats[]>('stats/most_visited_pages_last_month');

--- a/src/components/molecules/charts/pageVisitsLastMonthChart/VistsLastMonthChart.tsx
+++ b/src/components/molecules/charts/pageVisitsLastMonthChart/VistsLastMonthChart.tsx
@@ -1,0 +1,133 @@
+import { Flex } from '@chakra-ui/react';
+import { getPageVisitsLastMonth } from 'api';
+import { IPageStats } from 'models/apiModels';
+import { useEffect, useState } from 'react';
+import ReactEcharts from 'echarts-for-react';
+
+const VisitLastMonthChart = () => {
+  const [siteStats, setSiteStats] = useState<IPageStats[] | undefined>();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const fetchPageVisits = async () => {
+    try {
+      const res = await getPageVisitsLastMonth();
+      setSiteStats(res);
+    } catch (error) {
+      setErrorMessage('En feil skjedde ved henting av data');
+    }
+  };
+
+  useEffect(() => {
+    fetchPageVisits();
+  }, []);
+
+  return (
+    <Flex w="100%" h="100%" flexDir="column" textAlign="center">
+      {errorMessage === undefined ? (
+        <ReactEcharts
+          option={{
+            xAxis: {
+              name: 'Besøk',
+              type: 'value',
+              show: false,
+              axisLine: {
+                show: false,
+              },
+              z: 2,
+              axisTick: {
+                show: false,
+              },
+            },
+            yAxis: {
+              type: 'category',
+              show: true,
+              position: 'left',
+              axisLine: {
+                show: false,
+              },
+              z: 3,
+              axisTick: {
+                show: false,
+              },
+              axisLabel: {
+                color: '#FFF',
+                inside: true,
+                show: true,
+              },
+              nameLocation: 'start',
+            },
+            tooltip: {
+              trigger: 'axis',
+              axisPointer: {
+                type: 'none',
+              },
+            },
+            grid: {
+              containLable: true,
+              left: '4%',
+              top: '2.5%',
+              bottom: '2.5%',
+            },
+            series: [
+              {
+                type: 'bar',
+                // do not handle if the text and count number overflow i.e when the page has few visits
+                label: {
+                  show: true,
+                  align: 'right',
+                  verticalAlign: 'middle',
+                  position: 'insideRight',
+                  overflow: 'break',
+                  color: '#FFF',
+                },
+                datasetIndex: 1,
+                itemStyle: {
+                  color: {
+                    type: 'linear',
+                    x: 0,
+                    y: 0,
+                    x2: 1,
+                    y2: 0,
+                    colorStops: [
+                      {
+                        offset: 0,
+                        color: '#008D8E', // --histogram-item-gradient-background
+                      },
+                      {
+                        offset: 1,
+                        color: '#24C1C3', // color at 100%
+                      },
+                    ],
+                    global: false, // default is false
+                  },
+                  borderRadius: 6,
+                },
+              },
+            ],
+            dataset: [
+              {
+                // sets the name of keys in dict
+                dimensions: ['title', 'count'],
+                source: siteStats ?? [],
+              },
+              {
+                transform: {
+                  type: 'sort',
+                  config: { dimension: 'count', order: 'asc' },
+                },
+              },
+            ],
+            barWidth: '80%',
+            barGap: '80%',
+            barCategoryGap: '50%',
+          }}
+          style={{ display: 'flex', width: '100%' }}
+        />
+      ) : (
+        <p>{errorMessage}</p>
+      )}
+    </Flex>
+  );
+};
+
+export default VisitLastMonthChart;

--- a/src/components/molecules/charts/uniqueVisitChart/UniqueVisitChart.tsx
+++ b/src/components/molecules/charts/uniqueVisitChart/UniqueVisitChart.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState } from 'react';
+import ReactEcharts from 'echarts-for-react';
+import { getUniqueVisits } from 'api';
+import { IVisits } from 'models/apiModels';
+import { TooltipComponentFormatterCallbackParams, graphic } from 'echarts';
+import { DateOptions, manipulateDate } from 'utils/date';
+import { Select, Flex, useMediaQuery } from '@chakra-ui/react';
+
+type IntervalOptions = 'day' | 'week' | 'month' | 'year' | 'all-time';
+
+type IntervalDict = {
+  [key in IntervalOptions]: DateOptions;
+};
+
+export interface StringDict {
+  [key: string]: string;
+}
+
+const UniqueVisitsCharts = () => {
+  const [siteStats, setSiteStats] = useState<IVisits[] | undefined>();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [interval, setInterval] = useState<IntervalOptions>('month');
+  const [isLargerThan800] = useMediaQuery('(min-width: 768px)');
+  // dict containing the date manipulation
+  let dateInterval: IntervalDict = {
+    day: { day: -1 },
+    week: { day: -7 },
+    month: { month: -1 },
+    year: { year: -1 },
+    'all-time': {},
+  };
+
+  // dict to convert key to chart display in Norwegian
+  let keyToDisplayName: StringDict = {
+    date: 'Dato',
+    coun: 'Besøk',
+  };
+
+  const fetchUniqueVisits = async (period: IntervalOptions) => {
+    // removes millisecond
+    const currentDate = new Date();
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const startDate = manipulateDate(currentDate, dateInterval[period]);
+    // to get the desired format
+    const start = startDate.toLocaleString('sv-SE', { timeZone: tz });
+    try {
+      const res = await getUniqueVisits(
+        period === 'all-time' ? undefined : start
+      );
+      setSiteStats(res);
+    } catch (error) {
+      setErrorMessage('En feil skjedde ved henting av data');
+    }
+  };
+
+  const changeInterval = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setInterval(event.target.value as IntervalOptions);
+  };
+
+  useEffect(() => {
+    fetchUniqueVisits(interval);
+  }, [interval]);
+
+  return (
+    <Flex w="100%" height="100%" flexDir="column">
+      {errorMessage === undefined ? (
+        <>
+          <Flex w="100%">
+            <Flex w={`${isLargerThan800 ? 'auto' : '100%'}`}>
+              <Select
+                onChange={changeInterval}
+                value={interval}
+                alignSelf="flex-start">
+                <option value="day">I dag</option>
+                <option value="week">Siste 7 dagene</option>
+                <option value="month">Siste måned</option>
+                <option value="year">Siste år</option>
+                <option value="all-time">Hele historikken</option>
+              </Select>
+            </Flex>
+          </Flex>
+          <Flex width="100%" height="100%">
+            <ReactEcharts
+              option={{
+                xAxis: {
+                  name: 'Dato',
+                  // type of field in dict
+                  type: 'time',
+                  axisLabel: {
+                    formatter:
+                      interval === 'day'
+                        ? '{MM}-{dd} kl {HH}'
+                        : '{yyyy}-{MM}-{dd}',
+                    hideOverlap: true,
+                  },
+                },
+                yAxis: {
+                  name: 'Besøk',
+                  type: 'value',
+                  // removes vertical lines in background
+                  splitLine: {
+                    show: false,
+                  },
+                },
+                grid: {
+                  containLable: true,
+                  // handle mobile view
+                  left: `${isLargerThan800 ? '3%' : '10%'}`,
+                  right: `${isLargerThan800 ? '4%' : '15%'}`,
+                },
+                // allows data display on hover
+                tooltip: {
+                  trigger: 'axis',
+                  type: 'item',
+                  padding: 0,
+                  formatter: (
+                    params: TooltipComponentFormatterCallbackParams
+                  ): string => {
+                    // formatter can be either single value or array
+                    const param = Array.isArray(params) ? params[0] : params;
+                    // closet to a type safe tooltip as dimensionNames is not type as keyof data
+                    let string = '';
+                    Object.entries(param.data).forEach(([k, v]) => {
+                      // use display name if defined in dict
+                      string += `${keyToDisplayName[k] ?? k}: ${
+                        keyToDisplayName[v] ?? v
+                      } <br />`;
+                    });
+                    return string;
+                  },
+                },
+                series: [
+                  {
+                    type: 'line',
+                    smooth: 0.25,
+                    showSymbol: false,
+                    areaStyle: {
+                      color: new graphic.LinearGradient(0, 0, 0, 1, [
+                        {
+                          offset: 0,
+                          color: 'rgb(155, 175, 217)',
+                        },
+                        {
+                          offset: 1,
+                          color: 'rgb(16, 55, 131)',
+                        },
+                      ]),
+                    },
+                  },
+                ],
+                dataset: {
+                  // sets the name of keys in dict
+                  dimensions: ['date', 'count'],
+                  source: siteStats ?? [],
+                },
+              }}
+              style={{ display: 'flex', width: '100%' }}
+            />
+          </Flex>
+        </>
+      ) : (
+        <p>{errorMessage}</p>
+      )}
+    </Flex>
+  );
+};
+
+export default UniqueVisitsCharts;

--- a/src/components/molecules/forms/registerForm/RegisterForm.tsx
+++ b/src/components/molecules/forms/registerForm/RegisterForm.tsx
@@ -49,7 +49,7 @@ const RegisterForm = () => {
       return;
     }
     try {
-      const validationCode = await registerMember({
+      await registerMember({
         realName: fields['name'].value + ' ' + fields['lastname'].value,
         email: fields['email'].value,
         password: fields['password'].value,
@@ -57,7 +57,6 @@ const RegisterForm = () => {
         graduated: graduated,
         phone: fields['phone'].value,
       });
-      console.log(validationCode);
     } catch (error) {
       switch (error.statusCode) {
         case 400:

--- a/src/components/molecules/navbar/Navbar.tsx
+++ b/src/components/molecules/navbar/Navbar.tsx
@@ -35,11 +35,11 @@ const AuthNavbar = () => {
       <MenuItem label={'Profil'} path={'/profile'} />
       <MenuItem label={'Arrangement oversikt'} path={'/eventoverview'} />
       <MenuItem label={'Stillingsutlysninger'} path={'/jobs'} />
-
       {role === Roles.admin && (
         <MenuItem label={'Opprett Arrangement'} path={'/create-event'} />
       )}
       {role === Roles.admin && <MenuItem label={'Admin'} path={'/admin'} />}
+      {role === Roles.admin && <MenuItem label={'Stats'} path={'/stats'} />}
       <MenuItem label={'Logg ut'} path={'/'} onClick={onLogout} />
     </Menu>
   );

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -14,6 +14,7 @@ import RestorePasswordPage from './restorePassword/RestorePassword';
 import ResetPasswordPage from './resetPassword/ResetPassword';
 import AboutPage from './aboutTD/AboutPage';
 import NewStudentsPage from './newStudent/NewStudent';
+import StatsPage from './stats/StatsPage';
 
 import Jobs from './jobs/Jobs';
 import Job from './jobs/Job';
@@ -38,4 +39,5 @@ export {
   CreateJob,
   AboutPage,
   NewStudentsPage,
+  StatsPage,
 };

--- a/src/components/pages/stats/StatsPage.tsx
+++ b/src/components/pages/stats/StatsPage.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import UniqueVisitsCharts from 'components/molecules/charts/uniqueVisitChart/UniqueVisitChart';
+import { Flex, Heading, Card, CardBody, CardHeader } from '@chakra-ui/react';
+import VisitLastMonthChart from 'components/molecules/charts/pageVisitsLastMonthChart/VistsLastMonthChart';
+
+const UniqueChartBox: React.FC = () => {
+  return (
+    <Card
+      w="95%"
+      alignSelf="center"
+      variant={'outline'}
+      colorScheme="blue"
+      backgroundColor="unset">
+      <CardHeader margin={0}>Unike brukere</CardHeader>
+      <CardBody>
+        <UniqueVisitsCharts />
+      </CardBody>
+    </Card>
+  );
+};
+
+const PageVisitChartBox: React.FC = () => {
+  return (
+    <Card
+      w="90%"
+      mt={25}
+      alignSelf="center"
+      variant={'outline'}
+      colorScheme="blue"
+      backgroundColor="unset">
+      <CardHeader margin={0}>Mest besøkte sider siste 30 dager</CardHeader>
+      <CardBody>
+        <VisitLastMonthChart />
+      </CardBody>
+    </Card>
+  );
+};
+const StatsPage: React.FC = () => {
+  return (
+    <Flex w="100vw" h="100%" flexDir="column" textAlign="center" mb={50}>
+      <Heading mt={2.5}>Statistikk</Heading>
+      <UniqueChartBox />
+      <Flex w={{ base: '100%', md: '50%' }} h="50%" justifyContent={'center'}>
+        <PageVisitChartBox />
+      </Flex>
+    </Flex>
+  );
+};
+
+export default StatsPage;

--- a/src/contexts/analyticsProvider.tsx
+++ b/src/contexts/analyticsProvider.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, createContext, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+import { findParentPath } from 'utils/path';
+import { logVisit, postUniqueVisit } from 'api';
+import { IPageVisit } from 'models/apiModels';
+import { AuthenticateContext } from './authProvider';
+
+export interface IAnalytics {
+  // paths the context should track visits
+  paths: string[];
+  // optional: turn off tracking on localhost
+  localhost?: boolean;
+  children?: React.ReactNode;
+}
+
+// provider without sharing a value, the analytic context is only to ensure
+// the analytic logic runs on every route
+export const AnalyticsContext = createContext({
+  setUniqueVisit: (_: boolean) => {},
+});
+
+// uses state to avoid sending unnecessary unique visit requests
+// refresh resets the state
+const AnalyticsProvider = ({ paths, localhost, children }: IAnalytics) => {
+  const { authenticated, isValidating } = useContext(AuthenticateContext);
+  const [uniqueVisit, setUniqueVisit] = useState(false);
+  const location = useLocation();
+
+  const followUniqueVisit = () => {
+    const timeout = 1000 * 60 * 60 * 24;
+    // reset unique visit every day to avoid unnecessary requests to stats api
+    const timer = setInterval(() => setUniqueVisit(false), timeout);
+
+    return () => {
+      clearInterval(timer);
+    };
+  };
+
+  const validPath = (currentPath: string) => {
+    const parentPath = findParentPath(currentPath);
+    console.log(parentPath);
+    return parentPath !== undefined ? paths.includes(parentPath) : false;
+  };
+
+  const logUniqueVisit = async () => {
+    try {
+      // needs to await as errors will cause app to crash
+      await postUniqueVisit();
+      setUniqueVisit(true);
+    } catch (error) {
+      // ignores logging errors
+    }
+  };
+
+  const logUserVisit = async (currentPath: string) => {
+    if (localhost || !validPath(currentPath)) {
+      return;
+    }
+
+    const payload = { page: currentPath } as IPageVisit;
+    try {
+      // needs to await as errors will cause app to crash
+      await logVisit(payload);
+    } catch (error) {
+      console.log(error);
+      // ignores logging errors
+    }
+  };
+
+  useEffect(() => {
+    // reset unique visit state after 24 hours
+    followUniqueVisit();
+  }, []);
+
+  useEffect(() => {
+    if (isValidating || uniqueVisit) {
+      // wait until auth state is finished propagating
+      return;
+    }
+
+    if (!authenticated) {
+      // handles reseting state between login/logout
+      setUniqueVisit(false);
+      return;
+    }
+    logUniqueVisit();
+  }, [uniqueVisit, authenticated, isValidating]);
+
+  // tracks react router changes and logs the desired pages
+  useEffect(() => {
+    logUserVisit(location.pathname);
+    if (!uniqueVisit) {
+      logUniqueVisit();
+    }
+  }, [location.pathname]);
+
+  return (
+    <AnalyticsContext.Provider value={{ setUniqueVisit }}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+};
+
+export default AnalyticsProvider;

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -157,3 +157,18 @@ export type JobUpdate = Partial<
     | 'due_date'
   >
 >;
+
+export interface IPageVisit {
+  page: string;
+}
+
+export interface IPageStats {
+  path: string;
+  title: string;
+  count: number;
+}
+
+export interface IVisits {
+  count: number;
+  date: String;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,21 @@
+export interface DateOptions {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  seconds?: number;
+}
+
+// function to get a new date based on date and time input
+// the native Date objects handles all the date and time "overflows"
+export function manipulateDate(date: Date, dateOpt: DateOptions) {
+  return new Date(
+    date.getFullYear() + (dateOpt?.year ?? 0),
+    date.getMonth() + (dateOpt?.month ?? 0),
+    date.getDate() + (dateOpt?.day ?? 0),
+    date.getHours() + (dateOpt?.hour ?? 0),
+    date.getMinutes() + (dateOpt?.minute ?? 0),
+    date.getSeconds() + (dateOpt?.seconds ?? 0)
+  );
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,7 @@
+// find parent path in url path e.g. /event/something returns event as parent path
+export const findParentPath = (path: string): string | undefined => {
+  // capture everything between slashes without including the slashes
+  const exp = /(?<=\/).+?(?=\/)/;
+  const math = path.match(exp);
+  return math?.[0];
+};


### PR DESCRIPTION
## Frontend tracking and displaying unique visits and page visits 🕵️ 
**dependent on td-org-uit-no/tdctl-frontend#84 and closes #71**
### Analytics provider
Provider used for tracking unique users and page visits. The provider tracks:
  - Unique visits(once every 24 hors)
  - Pages inside the tracked path
 
The provider monitors the `event` and `jobs` pages

### Stats page
The stats page displays the unique visits graph. and the most viewed page in the last 30 days
#### unique visit page
The chart has five filters:
  - today
  - last 7 days
  - last month
  - last year
  - the entire history

https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/74684d98-6b16-4522-9935-cf9ade20cc8d
