### PR TITLE
Feature/improve no events response

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-markdown": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.1",
+    "react-snowfall": "^1.2.1",
     "sass": "^1.55.0",
     "typescript": "~4.3.5",
     "web-vitals": "^0.2.4"

--- a/src/components/atoms/loadingWrapper/LoadingWrapper.tsx
+++ b/src/components/atoms/loadingWrapper/LoadingWrapper.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@chakra-ui/react';
 import React, { useState, HTMLAttributes, useEffect } from 'react';
 import Loading from '../loading/Loading';
 
@@ -64,7 +65,7 @@ const LoadingWrapper: React.FC<LoadingWrapperInterface> = ({
     );
   }
 
-  return <div {...rest}>{render && <div {...rest}>{children} </div>}</div>;
+  return <Flex {...rest}>{render && <Flex {...rest}>{children} </Flex>}</Flex>;
 };
 
 export default LoadingWrapper;

--- a/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
+++ b/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
@@ -1,0 +1,45 @@
+import { Center, Flex, Heading, Text } from '@chakra-ui/react';
+import Snowfall from 'react-snowfall';
+
+const WinterResponse = () => {
+  return (
+    <Flex w="100%" height="100%" flexDir="column" textAlign="center">
+      <Snowfall
+        snowflakeCount={350}
+        speed={[0.5, 1.5]}
+        wind={[-0.5, 0.5]}
+        radius={[0.5, 4.5]}
+      />
+      <Heading>Vi har tatt vinterferie❄️ </Heading>
+      <Center>
+        <Text>Ses neste semester👋</Text>
+      </Center>
+    </Flex>
+  );
+};
+
+// TODO add more responses on for example Christmas, summer and so on
+const NoUpcomingEvents = () => {
+  const today = new Date();
+
+  const isWinterBreak = (today: Date): boolean => {
+    const year = today.getFullYear();
+    // winter break
+    const winterBreakStart = new Date(year, 12, 1);
+    const winterBreakEnd = new Date(year + 1, 1, 15);
+
+    return today >= winterBreakStart && today <= winterBreakEnd;
+  };
+
+  if (isWinterBreak(today)) {
+    return <WinterResponse />;
+  }
+
+  return (
+    <Flex w="100%" height="100%" flexDir="column">
+      <Heading>Ingen kommende arrangement 👀</Heading>
+    </Flex>
+  );
+};
+
+export default NoUpcomingEvents;

--- a/src/components/pages/homepage/HomePage.tsx
+++ b/src/components/pages/homepage/HomePage.tsx
@@ -7,11 +7,13 @@ import EventPreview from 'components/molecules/event/eventPreview/EventPreview';
 import useUpcomingEvents from 'hooks/useEvents';
 import LoadingWrapper from 'components/atoms/loadingWrapper/LoadingWrapper';
 import { useMobileScreen } from 'hooks/useMobileScreen';
+import NoUpcomingEvents from 'components/molecules/homePage/noUpcomingEventResponse/evnetResponse';
 
 const RootPage = () => {
-  const { events } = useUpcomingEvents();
   useTitle('Tromsøstudentenes-Dataforening');
+  const { events } = useUpcomingEvents();
   const isMobile = useMobileScreen();
+
   return (
     <div className={styles.root}>
       <HomeHeader />
@@ -40,9 +42,7 @@ const RootPage = () => {
                 </Carousel>
               </div>
             ) : (
-              <h3 style={{ minHeight: '45vh' }}>
-                Ingen kommende arrangementer{' '}
-              </h3>
+              <NoUpcomingEvents />
             )}
           </LoadingWrapper>
         </div>

--- a/src/components/pages/homepage/homePage.module.scss
+++ b/src/components/pages/homepage/homePage.module.scss
@@ -13,6 +13,7 @@
 .eventsWrapper {
   display: flex;
   justify-content: center;
+  text-align: center;
   width: 75vw;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9233,6 +9233,11 @@ react-fast-compare@3.2.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
   integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
 
+react-fast-compare@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
 react-focus-lock@^2.9.4:
   version "2.9.5"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.5.tgz#8a82f4f0128cccc27b9e77a4472e8a22f1b52189"
@@ -9392,6 +9397,18 @@ react-scripts@^5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-snow@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/react-snow/-/react-snow-0.0.1.tgz#92189142cf7ed68e15641ce3e951c6a9fe402644"
+  integrity sha512-YkgZZ2hjdzBuVa3ahiWxzBh5rjpMU0BLwRjiFXhJ6sGBvet80wZmQfxUbb0zAzQgdIK+lhlpnmzjE+sedU7dPQ==
+
+react-snowfall@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-snowfall/-/react-snowfall-1.2.1.tgz#68cab6a1d05aa7c3211bce96a3a97977ca7dc57f"
+  integrity sha512-d2UR3nDq3F0DJGaTfJ0QNbBo76UZHtT9wHFj+ePxAl4FgSxWBhxB/Bjn06f5iDBwhgwiZ7CZmv3lwfNvjo6a+w==
+  dependencies:
+    react-fast-compare "^3.2.0"
 
 react-style-singleton@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
### Add custom screen on winter break ☃️ 
<img width="1727" alt="Screenshot 2023-11-23 at 20 14 59" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/0970e838-a56e-4c5e-9279-5af554ffb9ef">

### Small fixes 🐛 
  - Use Flex in loadingWrapper
  - Align text in center when there are no upcoming events 