### PR TITLE
Fix/remove character restriction in name

### DIFF
--- a/src/components/atoms/textfield/Textfield.tsx
+++ b/src/components/atoms/textfield/Textfield.tsx
@@ -49,7 +49,6 @@ const TextField: React.FC<Props> = ({
         <div className={styles.inputContainer}>
           <input
             style={{
-              width: '100%',
               borderTopLeftRadius: prefix ? '0px' : '5px',
               borderBottomLeftRadius: prefix ? '0px' : '5px',
             }}

--- a/src/components/atoms/textfield/textfield.module.scss
+++ b/src/components/atoms/textfield/textfield.module.scss
@@ -3,6 +3,7 @@
 .inputFlex {
   display: flex;
   flex-direction: row;
+  justify-content: center;
 }
 
 .inputPrefix {

--- a/src/components/atoms/toggleButton/toggleButton.module.scss
+++ b/src/components/atoms/toggleButton/toggleButton.module.scss
@@ -5,6 +5,7 @@
   text-align: center;
   align-items: center;
 }
+
 .toggleContainer {
   display: flex;
   justify-content: center;
@@ -68,7 +69,6 @@ input:checked + .slider:before {
 
 .textContainer {
   text-align: center;
-  height: 100%;
   margin-left: 0.5em;
 }
 

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -144,7 +144,7 @@ const EventForm = () => {
         <TextField
           name={'title'}
           label={'Tittel'}
-          minWidth={40}
+          minWidth={20}
           onChange={onFieldChange}
           error={fields['title'].error}
         />
@@ -152,21 +152,21 @@ const EventForm = () => {
           name={'date'}
           label={'Dato'}
           type={'date'}
-          minWidth={40}
+          minWidth={20}
           onChange={onFieldChange}
         />
         <TextField
           name={'time'}
           label={'Tid'}
           type={'time'}
-          minWidth={40}
+          minWidth={20}
           onChange={onFieldChange}
         />
 
         <TextField
           name={'address'}
           label={'Adresse'}
-          minWidth={40}
+          minWidth={20}
           onChange={onFieldChange}
           error={fields['address'].error}
         />
@@ -174,7 +174,7 @@ const EventForm = () => {
         <TextField
           name={'price'}
           label={'Pris'}
-          minWidth={40}
+          minWidth={20}
           type={'number'}
           onChange={onFieldChange}
           error={fields['price'].error}
@@ -183,7 +183,7 @@ const EventForm = () => {
           name={'maxParticipants'}
           label={'Maks antall deltagere (valgfritt)'}
           type={'number'}
-          minWidth={40}
+          minWidth={20}
           onChange={onFieldChange}
           error={fields['maxParticipants'].error}
         />
@@ -191,7 +191,7 @@ const EventForm = () => {
         <Textarea
           name={'description'}
           label={'Beskrivelse'}
-          minWidth={65}
+          minWidth={25}
           onChange={onFieldChange}
           resize={true}
           error={fields['description'].error}
@@ -205,14 +205,14 @@ const EventForm = () => {
               name={'registerDate'}
               label={'Påmeldings dato'}
               type={'date'}
-              minWidth={40}
+              minWidth={20}
               onChange={onFieldChange}
             />
             <TextField
               name={'registerTime'}
               label={'Tid'}
               type={'time'}
-              minWidth={40}
+              minWidth={20}
               onChange={onFieldChange}
             />
           </div>

--- a/src/components/molecules/forms/registerForm/RegisterForm.tsx
+++ b/src/components/molecules/forms/registerForm/RegisterForm.tsx
@@ -143,7 +143,6 @@ const RegisterForm = () => {
         <TextField
           name={'phone'}
           type="text"
-          minWidth={40}
           label={'Telefon'}
           onChange={onFieldChange}
           error={fields['phone'].error}

--- a/src/components/molecules/forms/registerForm/RegisterForm.tsx
+++ b/src/components/molecules/forms/registerForm/RegisterForm.tsx
@@ -104,18 +104,16 @@ const RegisterForm = () => {
     useForm({ onSubmit: onSubmit, validators: validators });
 
   return (
-    <div className="contnet">
+    <div className="registerContent">
       <form onSubmit={onSubmitEvent}>
         <TextField
           name={'name'}
-          minWidth={40}
           label={'Fornavn'}
           onChange={onFieldChange}
           error={fields['name'].error}
         />
         <TextField
           name={'lastname'}
-          minWidth={40}
           label={'Etternavn'}
           onChange={onFieldChange}
           error={fields['lastname'].error}
@@ -123,7 +121,6 @@ const RegisterForm = () => {
         <TextField
           name={'email'}
           type="email"
-          minWidth={40}
           label={'E-post'}
           onChange={onFieldChange}
           error={fields['email'].error}
@@ -131,7 +128,6 @@ const RegisterForm = () => {
         <TextField
           name={'password'}
           type="password"
-          minWidth={40}
           label={'Passord'}
           onChange={onFieldChange}
           error={fields['password'].error}
@@ -140,7 +136,6 @@ const RegisterForm = () => {
         <TextField
           name={'classof'}
           type="text"
-          minWidth={40}
           label={'Studiestart'}
           onChange={onFieldChange}
           error={fields['classof'].error}
@@ -154,8 +149,8 @@ const RegisterForm = () => {
           error={fields['phone'].error}
         />
       </form>
-      <div>
-        <ToggleButton onChange={onGraduateToggle} label={'Graduated'} />
+      <div className="clickableSection">
+        <ToggleButton onChange={onGraduateToggle} label={'Uteksaminert'} />
         {errors && <p>{errors}</p>}
         <Button variant={'primary'} onClick={onSubmit} type="submit">
           Registrer

--- a/src/components/molecules/forms/registerForm/registerForm.scss
+++ b/src/components/molecules/forms/registerForm/registerForm.scss
@@ -12,3 +12,15 @@
     gap: 1rem;
   }
 }
+
+.clickableSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media screen and (max-width: 768px) {
+  .registerContent {
+    width: 100%;
+  }
+}

--- a/src/components/molecules/forms/registerForm/registerForm.scss
+++ b/src/components/molecules/forms/registerForm/registerForm.scss
@@ -1,14 +1,16 @@
-.contnet {
+.registerContent {
   display: flex;
+  width: 35%;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 1rem;
 
   form {
+    width: 90%;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    margin-bottom: 1rem;
     gap: 1rem;
   }
 }

--- a/src/components/molecules/passwordValidation/PasswordValidation.tsx
+++ b/src/components/molecules/passwordValidation/PasswordValidation.tsx
@@ -56,7 +56,6 @@ const PasswordValidation: React.FC<IPasswordValidation> = ({
     <div className={styles.info}>
       <TextField
         name={'password'}
-        minWidth={40}
         type="password"
         label={'Passord'}
         value={fields['password']?.value ?? ''}
@@ -66,7 +65,6 @@ const PasswordValidation: React.FC<IPasswordValidation> = ({
       <br />
       <TextField
         name={'newPassword'}
-        minWidth={40}
         type="password"
         label={'Nytt passord'}
         value={fields['newPassword']?.value ?? ''}

--- a/src/components/pages/register/register.module.scss
+++ b/src/components/pages/register/register.module.scss
@@ -5,6 +5,7 @@
   text-align: center;
   align-items: center;
   width: 100%;
+
 }
 
 .registerForm {
@@ -13,5 +14,13 @@
   width: 100%;
   input {
     min-width: 30ch;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .registerPage {
+    h1 {
+      font-size: 3.157rem;
+    }
   }
 }

--- a/src/components/pages/register/register.module.scss
+++ b/src/components/pages/register/register.module.scss
@@ -5,7 +5,6 @@
   text-align: center;
   align-items: center;
   width: 100%;
-
 }
 
 .registerForm {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -30,6 +30,8 @@ const theme = extendTheme(
         800: '#161926',
       },
       secondary: '#f8d2cc',
+      inputBackground: '#272530',
+      inputBorder: '#2f2c45',
     },
     components: {
       Button: {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -55,13 +55,20 @@ export const maxParticipantsValidator = (
 };
 
 export const nameValidator = (name: string): string[] | undefined => {
-  const nameReg = /^[a-zæøåA-ZÆØÅ ]+$/; //! note the last space
+  // \p{L} -> letter in any language
+  // \p{Zz} -> allows space
+  // 1,30 is the valid range
+  // must be an range or any name over one char gets an error
+  const nameReg = /^[\p{L}\p{Zs}]{1,30}$/u;
 
   if (name.length === 0) {
     return ['Navn er påkrevd'];
   }
+  if (name.length > 30) {
+    return ['Navnet er for langt, maks 30 bokstaver'];
+  }
   if (!new RegExp(nameReg).test(name)) {
-    return ['Kun bokstavene A-Å'];
+    return ['Kun bokstaver er gyldig'];
   }
   return undefined;
 };
@@ -70,6 +77,11 @@ export const lastNameValidator = (name: string): string[] | undefined => {
   if (name.length === 0) {
     return ['Etternavn er påkrevd'];
   }
+
+  if (name.length > 30) {
+    return ['Etternavnet er for langt, maks 30 bokstaver'];
+  }
+
   return nameValidator(name);
 };
 


### PR DESCRIPTION
## 🌐 Fix only Norwegian latters allowed in names
Resolved #225
Now all alphabets are valid characters in name all name validation fields
### Minor changes 🤠 
#### Input field overflowing parent div 🐛 
Currently the registration looks like this
<img width="537" alt="Screenshot 2023-12-22 at 16 14 23" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/1704c910-1d49-46a1-ab8c-b881f24d0918">
Now:
<img width="508" alt="Screenshot 2023-12-22 at 16 15 10" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/b8aa98bb-0a88-4cef-93ca-d69610c0dc81">

## Update with `-` and `'`
Now the regex only allow `-` and `'` when between characters so `---` or `   ` is not a valid name 
https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/fa1c6969-e696-40f3-bbc7-3afe0dbabbeb

