### PR TITLE
Fix/winter break interval

### DIFF
--- a/src/components/molecules/footer/Footer.tsx
+++ b/src/components/molecules/footer/Footer.tsx
@@ -85,8 +85,13 @@ const SponsorBanner = () => {
 };
 
 const Footer: React.FC = () => {
+  // uses margin auto, needs parent page to have minHeight=100vh if content is not over 100vh
   return (
-    <Flex my="2rem" w="100%" direction={{ base: 'column', lg: 'row' }}>
+    <Flex
+      my="2rem"
+      w="100%"
+      direction={{ base: 'column', lg: 'row' }}
+      mt="auto">
       <Flex justify="space-evenly" width={{ base: '100%', lg: '60%' }}>
         <FooterList header={'Ressurser'}>
           <FooterItem label={'Om TD'} path={'/about-us'} />

--- a/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
+++ b/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
@@ -24,10 +24,16 @@ const NoUpcomingEvents = () => {
 
   const isWinterBreak = (today: Date): boolean => {
     const year = today.getFullYear();
-    // winter break
+    const isDecember = today.getMonth() === 11;
+
+    // end date needs to be currentYear + 1 before new years and currentYear after
+    // and start must do the same but with - 1
+    let endYear = isDecember ? year + 1 : year;
+    let startYear = isDecember ? year : year - 1;
+
     // 0 index so winter break starts 01.12
-    const winterBreakStart = new Date(year, 11, 1);
-    const winterBreakEnd = new Date(year + 1, 0, 15);
+    const winterBreakStart = new Date(startYear, 11, 1);
+    const winterBreakEnd = new Date(endYear, 0, 15);
 
     return today >= winterBreakStart && today <= winterBreakEnd;
   };

--- a/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
+++ b/src/components/molecules/homePage/noUpcomingEventResponse/evnetResponse.tsx
@@ -43,7 +43,7 @@ const NoUpcomingEvents = () => {
   }
 
   return (
-    <Flex w="100%" height="100%" flexDir="column">
+    <Flex w="100%" height="100%" flexDir="column" textAlign="center">
       <Heading>Ingen kommende arrangementer 👀</Heading>
     </Flex>
   );

--- a/src/components/pages/homepage/HomePage.tsx
+++ b/src/components/pages/homepage/HomePage.tsx
@@ -15,7 +15,7 @@ const RootPage = () => {
   const isMobile = useMobileScreen();
 
   return (
-    <VStack>
+    <VStack minH="100vh">
       <HomeHeader />
       <Center w={{ base: '85vw', xl: '75vw' }} mb={'1rem'}>
         <LoadingWrapper data={events} animation={true} startAfter={400}>


### PR DESCRIPTION
### Fixes bug on winter break interval on new year
The interval needs did not handle the correct year when going over to the new year as it needs to use `year - 1` to get `01.12` of the previous year
### Fixes other small UI bugs
 - Centers text
 - Uses `margin:auto` on footer to allow footer to be on the bottom of the page even if there is not enough content to fill the page
<img width="1722" alt="Screenshot 2024-01-01 at 15 17 56" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/dfcbad1b-d444-42fe-bdd0-8015f2713f73">

***After***

<img width="1723" alt="Screenshot 2024-01-01 at 15 23 03" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/43537864/ee879642-c064-4816-97b9-dd054630cbf1">
