### PR TITLE
Feature/custom confirmation

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -7,6 +7,7 @@ import {
   ParticipantsUpdate,
   SetAttendancePayload,
   ConfirmMessagePayload,
+  EventMailPayload,
 } from 'models/apiModels';
 import { get, post, put, Delete } from './requests';
 
@@ -78,6 +79,9 @@ export const getQR = (eid: string) => get<Blob>('event/' + eid + '/qr');
 
 export const exportEvent = (eid: string): Promise<{}> =>
   get<{}>('event/' + eid + '/export');
+
+export const sendMail = (eid: string, payload: EventMailPayload) =>
+  post<{}>('event/' + eid + '/mail', payload);
 
 export const getConfirmationMessage = (eid: string) =>
   get<{ message: string }>('event/' + eid + '/confirm-message');

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -6,6 +6,7 @@ import {
   JoinEventPayload,
   ParticipantsUpdate,
   SetAttendancePayload,
+  ConfirmMessagePayload,
 } from 'models/apiModels';
 import { get, post, put, Delete } from './requests';
 
@@ -78,8 +79,13 @@ export const getQR = (eid: string) => get<Blob>('event/' + eid + '/qr');
 export const exportEvent = (eid: string): Promise<{}> =>
   get<{}>('event/' + eid + '/export');
 
-export const confirmEvent = (eid: string): Promise<{}> =>
-  post<{}>('event/' + eid + '/confirm', {});
+export const getConfirmationMessage = (eid: string) =>
+  get<{ message: string }>('event/' + eid + '/confirm-message');
+
+export const confirmEvent = (
+  eid: string,
+  payload: ConfirmMessagePayload
+): Promise<{}> => post<{}>('event/' + eid + '/confirm', payload);
 
 export const reorderParticipants = (
   eid: string,

--- a/src/components/molecules/event/eventBody/EventBody.tsx
+++ b/src/components/molecules/event/eventBody/EventBody.tsx
@@ -17,7 +17,6 @@ import {
   timeValidator,
   PNGImageValidator,
   eventTitleValidator,
-  optionalDateValidator,
 } from 'utils/validators';
 import useForm from 'hooks/useForm';
 import { useHistory } from 'react-router-dom';
@@ -74,7 +73,6 @@ export const EditEvent: React.FC<{ event: Event; setEdit: () => void }> = ({
     address: addressValidator,
     maxParticipants: maxParticipantsValidator,
     price: priceValidator,
-    registerDate: optionalDateValidator,
   };
 
   const submit = async () => {

--- a/src/components/molecules/event/eventRegistrationQR/EventRegistrationQR.tsx
+++ b/src/components/molecules/event/eventRegistrationQR/EventRegistrationQR.tsx
@@ -63,7 +63,7 @@ const EventRegistrationQR: React.FC<{ event: Event }> = ({ event }) => {
   return (
     <div>
       <Button
-        variant={'secondary'}
+        variant={'primary'}
         onClick={() => {
           handleButtonClick(event.eid);
         }}>

--- a/src/components/molecules/event/eventResponses/EventResponses.tsx
+++ b/src/components/molecules/event/eventResponses/EventResponses.tsx
@@ -164,7 +164,7 @@ const EventResponses: React.FC<{
     }
     const recipients = event.participants.filter((p) => {
       if (confirmedOnly) {
-        return p.confirmed == true;
+        return p.confirmed === true;
       }
       return !p.confirmed;
     });

--- a/src/components/molecules/event/eventViewCount/EventViewCount.tsx
+++ b/src/components/molecules/event/eventViewCount/EventViewCount.tsx
@@ -18,7 +18,7 @@ const EventViewCount: React.FC<{ page: string }> = ({ page }) => {
   return (
     <Center
       w="100%"
-      height="20%"
+      height={100}
       borderRadius="lg"
       border="1px"
       borderColor="#fffff"

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -116,6 +116,10 @@ export interface SetAttendancePayload {
   attendance: boolean;
 }
 
+export interface ConfirmMessagePayload {
+  msg?: string;
+}
+
 export interface JobItem {
   id: string;
   company: string;

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -120,6 +120,12 @@ export interface ConfirmMessagePayload {
   msg?: string;
 }
 
+export interface EventMailPayload {
+  subject: string;
+  msg: string;
+  confirmedOnly?: boolean;
+}
+
 export interface JobItem {
   id: string;
   company: string;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -134,6 +134,24 @@ export const phoneValidator = (num: string): string[] | undefined => {
   return undefined;
 };
 
+export const mailSubjectValidator = (subject: string) => {
+  if (subject.length) {
+    return subject.length <= 50
+      ? undefined
+      : ['Emnefelt kan ikke overstige 50 tegn'];
+  }
+  return ['Emnefelt må fylles ut'];
+};
+
+export const mailContentValidator = (content: string) => {
+  if (content.length) {
+    return content.length <= 5000
+      ? undefined
+      : ['Epost kan ikke overstige 5000 tegn'];
+  }
+  return ['Epostinnhold må fylles ut'];
+};
+
 export const eventTitleValidator = (title: string) => {
   return title.length ? undefined : ['Arrangement tittelen må fylles ut'];
 };


### PR DESCRIPTION
# :gem: Custom emails to event participants

## :sparkles: Added ability for admin to input custom body for confirmation email
![image](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/b2655976-bacf-4af1-9658-6836c912f6e8)
Default email is fetched from API and can be edited in the modal

## :sparkles: Added button to send a custom email to event participants
![image](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/3548ea70-0a17-469d-bdeb-34bb3eb0f6e6)
Choose between sending mail to all participants or confirmed participants

## :lipstick: Fix styling of component displaying event views
:camera: Before
![image](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/ad24ae9e-d743-4644-ba8f-3143621b9023)
:camera: After
![image](https://github.com/td-org-uit-no/tdctl-frontend/assets/73795796/c74573fc-6671-4747-8d6e-d56378ef1f99)

### :warning: Must be merged together with corresponding API pr