### PR TITLE
:lipstick: Makes filter tags uniform

### DIFF
--- a/src/components/pages/jobs/jobs.module.scss
+++ b/src/components/pages/jobs/jobs.module.scss
@@ -28,13 +28,15 @@
   display: flex;
   width: 90%;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 .chip {
-  display: flex;
   color: white;
   padding: 0.2rem;
   border-radius: 5px;
+  text-align: center;
+  text-transform: capitalize;
+  min-width: 3rem;
   font-size: 0.5rem;
   cursor: pointer;
 }


### PR DESCRIPTION
Adds the same min width as the job card tags. Also makes text center aligned and capitalized.

This makes the tags easier to click and makes them a bit more pleasing to look at imho