### PR TITLE
Bug/calendar icon cursor

### DIFF
--- a/src/components/atoms/icons/icon.tsx
+++ b/src/components/atoms/icons/icon.tsx
@@ -7,13 +7,18 @@ interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   cursor?: string;
 }
 
-const Icon = ({ type, size = 1, color = 'white', cursor='pointer', onClick }: Props) => (
+const Icon = ({
+  type,
+  size = 1,
+  color = 'white',
+  cursor = 'pointer',
+  onClick,
+}: Props) => (
   <span
     className={`las la-${type}`}
     style={{ fontSize: `${size}rem`, cursor: cursor, color: color }}
     onClick={onClick}
   />
-)
-;
+);
 export default Icon;
 <p>Test</p>;

--- a/src/components/atoms/icons/icon.tsx
+++ b/src/components/atoms/icons/icon.tsx
@@ -9,7 +9,7 @@ interface Props extends React.HTMLAttributes<HTMLSpanElement> {
 const Icon = ({ type, size = 1, color = 'white', onClick }: Props) => (
   <span
     className={`las la-${type}`}
-    style={{ fontSize: `${size}rem`, cursor: 'pointer', color: color }}
+    style={{ fontSize: `${size}rem`, color: color }}
     onClick={onClick}
   />
 );

--- a/src/components/atoms/icons/icon.tsx
+++ b/src/components/atoms/icons/icon.tsx
@@ -4,14 +4,16 @@ interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   type: string;
   size?: number;
   color?: string;
+  cursor?: string;
 }
 
-const Icon = ({ type, size = 1, color = 'white', onClick }: Props) => (
+const Icon = ({ type, size = 1, color = 'white', cursor='pointer', onClick }: Props) => (
   <span
     className={`las la-${type}`}
-    style={{ fontSize: `${size}rem`, color: color }}
+    style={{ fontSize: `${size}rem`, cursor: cursor, color: color }}
     onClick={onClick}
   />
-);
+)
+;
 export default Icon;
 <p>Test</p>;

--- a/src/components/molecules/tables/eventTable/eventTable.tsx
+++ b/src/components/molecules/tables/eventTable/eventTable.tsx
@@ -98,11 +98,23 @@ const EventTable = () => {
         return (
           <>
             {active ? (
-              <Icon type="calendar-check" cursor="default" color="green" size={2}></Icon>
-            ) : (dateOri.getTime() > dateNow2.getTime()) ? (
-              <Icon type="calendar-day" cursor="default" color="orange" size={2}></Icon>
+              <Icon
+                type="calendar-check"
+                cursor="default"
+                color="green"
+                size={2}></Icon>
+            ) : dateOri.getTime() > dateNow2.getTime() ? (
+              <Icon
+                type="calendar-day"
+                cursor="default"
+                color="orange"
+                size={2}></Icon>
             ) : (
-              <Icon type="calendar-times" cursor="default" color="red" size={2}></Icon>
+              <Icon
+                type="calendar-times"
+                cursor="default"
+                color="red"
+                size={2}></Icon>
             )}
           </>
         );

--- a/src/components/molecules/tables/eventTable/eventTable.tsx
+++ b/src/components/molecules/tables/eventTable/eventTable.tsx
@@ -98,11 +98,11 @@ const EventTable = () => {
         return (
           <>
             {active ? (
-              <Icon type="calendar-check" color="green" size={2}></Icon>
-            ) : dateOri.getTime() > dateNow2.getTime() ? (
-              <Icon type="calendar-day" color="orange" size={2}></Icon>
+              <Icon type="calendar-check" cursor="default" color="green" size={2}></Icon>
+            ) : (dateOri.getTime() > dateNow2.getTime()) ? (
+              <Icon type="calendar-day" cursor="default" color="orange" size={2}></Icon>
             ) : (
-              <Icon type="calendar-times" color="red" size={2}></Icon>
+              <Icon type="calendar-times" cursor="default" color="red" size={2}></Icon>
             )}
           </>
         );

--- a/src/components/pages/admin/AdminPage.tsx
+++ b/src/components/pages/admin/AdminPage.tsx
@@ -70,8 +70,25 @@ const AdminPage = () => {
         />
       </div>
       <div className={styles.content}>
-        <h4>{componentKey}</h4>
-        <div style={{ width: '100%', display: 'flex' }}>
+      <div>
+          <h4 style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span>{componentKey}</span>
+            {componentKey === 'Events' && (
+              <span style={{display: 'flex', flexDirection: 'row'}}>
+                <p style={{ fontSize: '20px', margin: '0 8px' }}>
+                  Active: <Icon type="calendar-check" color="green" style={{ fontSize: '20px', cursor: 'default'}}/>
+                </p>
+                <p style={{ fontSize: '20px', margin: '0 8px' }}>
+                  Upcoming: <Icon type="calendar-day" color="orange" style={{ fontSize: '20px', cursor: 'default' }}/>
+                </p>
+                <p style={{ fontSize: '20px', margin: '0 8px' }}>
+                  Inactive: <Icon type="calendar-times" color="red" style={{ fontSize: '20px', cursor: 'default' }}/>
+                </p>
+              </span>
+            )}
+          </h4>
+        </div>
+        <div style={{ width: '100%', display: 'flex', gap: '5rem', justifyContent: 'space-between'}}>
           {components[componentKey]}
         </div>
       </div>

--- a/src/components/pages/admin/AdminPage.tsx
+++ b/src/components/pages/admin/AdminPage.tsx
@@ -87,8 +87,8 @@ const AdminPage = () => {
                     type="calendar-check"
                     cursor="default"
                     color="green"
-                    style={{ fontSize: '20px'}}
-                    />
+                    style={{ fontSize: '20px' }}
+                  />
                 </p>
                 <p style={{ fontSize: '20px', margin: '0 8px' }}>
                   Upcoming:{' '}
@@ -96,8 +96,8 @@ const AdminPage = () => {
                     type="calendar-day"
                     cursor="default"
                     color="orange"
-                    style={{ fontSize: '20px'}}
-                    />
+                    style={{ fontSize: '20px' }}
+                  />
                 </p>
                 <p style={{ fontSize: '20px', margin: '0 8px' }}>
                   Inactive:{' '}

--- a/src/components/pages/admin/AdminPage.tsx
+++ b/src/components/pages/admin/AdminPage.tsx
@@ -70,25 +70,55 @@ const AdminPage = () => {
         />
       </div>
       <div className={styles.content}>
-      <div>
-          <h4 style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <h4
+            style={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}>
             <span>{componentKey}</span>
             {componentKey === 'Events' && (
-              <span style={{display: 'flex', flexDirection: 'row'}}>
+              <span style={{ display: 'flex', flexDirection: 'row' }}>
                 <p style={{ fontSize: '20px', margin: '0 8px' }}>
-                  Active: <Icon type="calendar-check" color="green" style={{ fontSize: '20px', cursor: 'default'}}/>
+                  Active:{' '}
+                  <Icon
+                    type="calendar-check"
+                    cursor="default"
+                    color="green"
+                    style={{ fontSize: '20px'}}
+                    />
                 </p>
                 <p style={{ fontSize: '20px', margin: '0 8px' }}>
-                  Upcoming: <Icon type="calendar-day" color="orange" style={{ fontSize: '20px', cursor: 'default' }}/>
+                  Upcoming:{' '}
+                  <Icon
+                    type="calendar-day"
+                    cursor="default"
+                    color="orange"
+                    style={{ fontSize: '20px'}}
+                    />
                 </p>
                 <p style={{ fontSize: '20px', margin: '0 8px' }}>
-                  Inactive: <Icon type="calendar-times" color="red" style={{ fontSize: '20px', cursor: 'default' }}/>
+                  Inactive:{' '}
+                  <Icon
+                    type="calendar-times"
+                    cursor="default"
+                    color="red"
+                    style={{ fontSize: '20px' }}
+                  />
                 </p>
               </span>
             )}
           </h4>
         </div>
-        <div style={{ width: '100%', display: 'flex', gap: '5rem', justifyContent: 'space-between'}}>
+        <div
+          style={{
+            width: '100%',
+            display: 'flex',
+            gap: '5rem',
+            justifyContent: 'space-between',
+          }}>
           {components[componentKey]}
         </div>
       </div>


### PR DESCRIPTION
# :gem: Changes

Closes [#223]

Use a list to express the changes if there are multiple:
- Made default cursor for Icons as pointer, but made it possible to pass type as parameter on demand
- Added a name for each calendar icon next to the header. previous ones meant nothing

<img width="1171" alt="image" src="https://github.com/td-org-uit-no/tdctl-frontend/assets/111961782/82f192f1-5d3f-4a6c-a4c4-90f2ca69949f">

