### PR TITLE
✨Add feature for: prioritization of årskull to events

### DIFF
--- a/src/components/atoms/dropdown/dropdownHeader/DropdownHeader.tsx
+++ b/src/components/atoms/dropdown/dropdownHeader/DropdownHeader.tsx
@@ -7,14 +7,21 @@ interface Props extends React.HtmlHTMLAttributes<HTMLDivElement> {
   title: string;
 }
 
-const DropdownHeader: React.FC<Props> = ({ title, children, ...rest }) => {
+const DropdownHeader: React.FC<Props> = ({
+  title,
+  children,
+  className,
+  ...rest
+}) => {
   const [expanded, setExpanded] = useState(false);
 
   const onExpand = () => setExpanded(!expanded);
 
   return (
     <div className={styles.container}>
-      <div className={styles.box} {...rest}>
+      <div
+        className={className ? `${styles.box} ${className}` : styles.box}
+        {...rest}>
         <div className={styles.base} onClick={onExpand}>
           <div className={styles.item2}>
             <p>{title}</p>

--- a/src/components/atoms/textfield/Textfield.tsx
+++ b/src/components/atoms/textfield/Textfield.tsx
@@ -21,13 +21,19 @@ const TextField: React.FC<Props> = ({
   value,
   defaultValue,
   type,
+  placeholder,
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [defaultInput, setDefaultInput] = useState(defaultValue);
   const styleLabel = () => {
     return (
-      value || defaultInput || isFocused || type === 'date' || type === 'time'
+      value ||
+      defaultInput ||
+      isFocused ||
+      type === 'date' ||
+      type === 'time' ||
+      placeholder
     );
   };
 
@@ -60,6 +66,7 @@ const TextField: React.FC<Props> = ({
             defaultValue={defaultValue}
             value={value}
             type={type}
+            placeholder={placeholder}
             onFocus={(e) => {
               setIsFocused(true);
               onFocus && onFocus(e);

--- a/src/components/molecules/event/eventBody/EventBody.tsx
+++ b/src/components/molecules/event/eventBody/EventBody.tsx
@@ -534,7 +534,7 @@ export const EventInfo: React.FC<{ event: Event; role: RoleOptions }> = ({
                   event.prioritizedYears?.includes(parseInt(userClassof)) ? (
                     <div>
                       {event.registrationOpeningDate && (
-                        <p style={{ fontWeight: 'lighter' }}>
+                        <p className={styles.registrationDate}>
                           {transformDate(
                             new Date(event.registrationOpeningDate)
                           )}
@@ -542,7 +542,7 @@ export const EventInfo: React.FC<{ event: Event; role: RoleOptions }> = ({
                       )}
                       <Text
                         fontSize="0.75rem"
-                        style={{ fontStyle: 'italic', color: '#4CAF50' }}>
+                        className={styles.prioritizedInfo}>
                         For årskull {event.prioritizedYears.join(', ')}:{' '}
                         {transformDate(
                           new Date(event.prioritizedRegistrationDate)
@@ -550,7 +550,7 @@ export const EventInfo: React.FC<{ event: Event; role: RoleOptions }> = ({
                       </Text>
                     </div>
                   ) : event.registrationOpeningDate ? (
-                    <p style={{ fontWeight: 'lighter' }}>
+                    <p className={styles.registrationDate}>
                       {transformDate(new Date(event.registrationOpeningDate))}
                     </p>
                   ) : (
@@ -565,15 +565,13 @@ export const EventInfo: React.FC<{ event: Event; role: RoleOptions }> = ({
           {role === 'admin' && (
             <div>
               {event.prioritizedRegistrationDate && event.prioritizedYears && (
-                <Text
-                  fontSize="0.75rem"
-                  style={{ fontStyle: 'italic', color: '#4CAF50' }}>
+                <Text fontSize="0.75rem" className={styles.prioritizedInfo}>
                   Åpner for årskull {event.prioritizedYears.join(', ')}{' '}
                   {transformDate(new Date(event.prioritizedRegistrationDate))}
                 </Text>
               )}
               {event.registrationOpeningDate && (
-                <Text fontSize="0.75rem" style={{ fontStyle: 'italic' }}>
+                <Text fontSize="0.75rem" className={styles.adminInfo}>
                   Åpner for alle{' '}
                   {transformDate(new Date(event.registrationOpeningDate))}
                 </Text>

--- a/src/components/molecules/event/eventBody/eventBody.module.scss
+++ b/src/components/molecules/event/eventBody/eventBody.module.scss
@@ -120,6 +120,19 @@ input[type='time']::-webkit-calendar-picker-indicator {
   gap: 0.25rem;
 }
 
+.registrationDate {
+  font-weight: lighter;
+}
+
+.prioritizedInfo {
+  font-style: italic;
+  color: #4caf50;
+}
+
+.adminInfo {
+  font-style: italic;
+}
+
 @mixin mobile_base {
   .contentContainer {
     display: inline;

--- a/src/components/molecules/forms/eventForm/EventForm.tsx
+++ b/src/components/molecules/forms/eventForm/EventForm.tsx
@@ -263,7 +263,7 @@ const EventForm = () => {
 
         <DropdownHeader
           title={'Valgfritt: Sett dato for når påmeldingen åpner'}
-          style={{ width: '100%', padding: '20px' }}>
+          className={styles.dropdownWithPadding}>
           <TextField
             name={'registerDate'}
             label={'Påmeldings dato'}
@@ -281,7 +281,7 @@ const EventForm = () => {
         </DropdownHeader>
         <DropdownHeader
           title={'Valgfritt: Prioritert påmelding for spesifikke årskull'}
-          style={{ width: '100%', padding: '20px' }}>
+          className={styles.dropdownWithPadding}>
           <TextField
             name={'prioritizedRegisterDate'}
             label={'Prioritert påmeldings dato'}

--- a/src/components/molecules/forms/eventForm/eventForm.module.scss
+++ b/src/components/molecules/forms/eventForm/eventForm.module.scss
@@ -86,6 +86,11 @@ input[type='time']::-webkit-calendar-picker-indicator {
   }
 }
 
+.dropdownWithPadding {
+  width: 100%;
+  padding: 20px;
+}
+
 @media screen and (max-width: 768px) {
   .eventContainer {
     width: 100%;

--- a/src/components/molecules/forms/settingsForm/SettingsForm.tsx
+++ b/src/components/molecules/forms/settingsForm/SettingsForm.tsx
@@ -121,6 +121,7 @@ const SettingsForm: React.FC<Props> = ({ init }) => {
             type="number"
             onChange={onFieldChange}
             error={fields['classof'].error}
+            disabled={!!init?.classof}
           />
           {init?.phone ? (
             <>

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -87,6 +87,8 @@ export interface Event {
   transportation: boolean;
   public: boolean;
   registrationOpeningDate?: string;
+  prioritizedRegistrationDate?: string;
+  prioritizedYears?: number[];
   confirmed?: boolean;
 }
 
@@ -101,6 +103,8 @@ export type EventUpdate = Partial<
     | 'maxParticipants'
     | 'public'
     | 'confirmed'
+    | 'prioritizedRegistrationDate'
+    | 'prioritizedYears'
   >
 >;
 export type CreateEvent = Omit<Event, 'eid' | 'host'>;
@@ -192,4 +196,11 @@ export interface ProductSuggestion {
   product: string;
   timestamp: Date;
   username: string;
+}
+
+// Priority feature models
+export interface Priority {
+  id: string;
+  value: number;
+  type: string;
 }

--- a/src/styles/text.scss
+++ b/src/styles/text.scss
@@ -91,7 +91,6 @@ input:-webkit-autofill:active {
 
 .text::placeholder {
   font-size: 16px;
-  opacity: 0;
   transition: all 0.3s;
 }
 .text:focus::placeholder {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -240,3 +240,33 @@ export const JobTitleValidator = (title: string) => {
 export const PNGImageValidator = (file: File) => {
   return file.type !== 'image/png' ? 'Kun PNG filer er støttet' : undefined;
 };
+
+export const prioritizedYearsValidator = (
+  years: string
+): string[] | undefined => {
+  if (!years.trim()) {
+    return undefined; // Optional field
+  }
+
+  const yearArray = years.split(',');
+  const errors: string[] = [];
+
+  for (const year of yearArray) {
+    const trimmedYear = year.trim();
+    if (!numberValidator(trimmedYear)) {
+      errors.push('Alle årskull må være tall');
+      break;
+    }
+    if (trimmedYear.length !== 4) {
+      errors.push('Årskull må være på formen YYYY');
+      break;
+    }
+    const currentYear = new Date().getFullYear();
+    if (Number(trimmedYear) > currentYear || Number(trimmedYear) < 1968) {
+      errors.push('Ikke godkjent årstall');
+      break;
+    }
+  }
+
+  return errors.length > 0 ? errors : undefined;
+};


### PR DESCRIPTION
This PR implements a priority registration system that allows specific årskull (graduation year) cohorts to register for events before the general registration opens. This addresses the need to give certain year groups early access to limited capacity events.

- Implement priority registration date and time fields
- Add validation for prioritized years (comma-separated format)
- Update event models with new prioritizedRegistrationDate and prioritizedYears fields
- Show priority registration info to eligible users in EventBody component
- Add disabling of 'classof' field in user settings if a year already is set

View for eglible member
<img width="867" height="648" alt="image" src="https://github.com/user-attachments/assets/cee1911b-dc51-4d8b-b5bd-3b16e3da86ad" />

View for regular members
<img width="782" height="545" alt="image" src="https://github.com/user-attachments/assets/82b512e6-23a4-4ab4-8495-3f1a3ef880c2" />

View for admins when creating an event
<img width="1100" height="835" alt="image" src="https://github.com/user-attachments/assets/b3ea85da-694a-40b2-87b4-56190a4301f6" />


