### PR TITLE
add metadata to job pages

### DIFF
--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -17,6 +17,7 @@ import ReactMarkdown from 'react-markdown';
 import LoadingWrapper from 'components/atoms/loadingWrapper/LoadingWrapper';
 import Footer from 'components/molecules/footer/Footer';
 import JobForm from 'components/molecules/forms/jobForm/JobForm';
+import { createPortal } from 'react-dom';
 
 interface IValidJob {
   jobData: JobItem | undefined;
@@ -34,6 +35,16 @@ export const ValidJob: React.FC<IValidJob> = ({ jobData, isPreview }) => {
       <Footer />
     </div>
   );
+};
+
+interface IValidHead {
+  children: React.ReactNode;
+}
+
+const HeadPortal = ({ children }: IValidHead): React.ReactPortal => {
+  return createPortal(<>
+    {children}
+  </>, document.head);
 };
 
 interface IValidJobLayout {
@@ -65,6 +76,14 @@ const ValidJobLayout: React.FC<IValidJobLayout> = ({ jobData, isPreview }) => {
       ) : (
         <>
           <div className={'pageWrapper'}>
+            <HeadPortal>
+              <meta property="og:title" content={jobData.title}/>
+              <meta property="og:description" content={jobData.description_preview}/>
+              <meta property="og:image" content={imgUrl}/>
+              <meta property="og:url" content={jobData.link}/>
+              <meta property="og:type" content="article"/> 
+              <meta prefix="og: http://ogp.me/ns#"/>
+            </HeadPortal>
             <div>
               <div className={'content'}>
                 <div className={'sidebar'}>

--- a/src/components/pages/jobs/Job.tsx
+++ b/src/components/pages/jobs/Job.tsx
@@ -41,10 +41,8 @@ interface IValidHead {
   children: React.ReactNode;
 }
 
-const HeadPortal = ({ children }: IValidHead): React.ReactPortal => {
-  return createPortal(<>
-    {children}
-  </>, document.head);
+const HeadPortal: React.FC<IValidHead> = ({ children }) => {
+  return createPortal(<>{children}</>, document.head);
 };
 
 interface IValidJobLayout {
@@ -77,12 +75,15 @@ const ValidJobLayout: React.FC<IValidJobLayout> = ({ jobData, isPreview }) => {
         <>
           <div className={'pageWrapper'}>
             <HeadPortal>
-              <meta property="og:title" content={jobData.title}/>
-              <meta property="og:description" content={jobData.description_preview}/>
-              <meta property="og:image" content={imgUrl}/>
-              <meta property="og:url" content={jobData.link}/>
-              <meta property="og:type" content="article"/> 
-              <meta prefix="og: http://ogp.me/ns#"/>
+              <meta property="og:title" content={jobData.title} />
+              <meta
+                property="og:description"
+                content={jobData.description_preview}
+              />
+              <meta property="og:image" content={imgUrl} />
+              <meta property="og:url" content={jobData.link} />
+              <meta property="og:type" content="article" />
+              <meta prefix="og: http://ogp.me/ns#" />
             </HeadPortal>
             <div>
               <div className={'content'}>


### PR DESCRIPTION
# 🔀 Add Open Graph Meta Tags via React Portal

This PR adds Open Graph (OG) meta tags dynamically for job posts using a React Portal. These tags are injected into the document head to improve SEO and social media link previews when a job is shared.

Closes Issue #303

<!-- Explain what you are changing and WHY you are changing it.
Use a list to express the changes if there are multiple:
- A change
  -  A subchange
- Another change

You should upload a picture of your changes if applicable. Drag & drop or paste from clipboard.
-->
