### PR TITLE
:bug: fetch removed participants after list reorder

### DIFF
--- a/src/components/molecules/event/eventResponses/EventResponses.tsx
+++ b/src/components/molecules/event/eventResponses/EventResponses.tsx
@@ -412,6 +412,9 @@ const EventResponses: React.FC<{
 
     try {
       await reorderParticipants(event.eid, { updateList: updateList });
+      // "ghost participants" may have been deleted during reorder,
+      // so we update the table in case.
+      setFetchUpdateHook(true);
       addToast({
         title: 'Suksess',
         status: 'success',


### PR DESCRIPTION
# :gem: Changes

Fixes an issue in connection with https://github.com/td-org-uit-no/tdctl-frontend/issues/324. If [this PR](https://github.com/td-org-uit-no/tdctl-api/pull/108) gets merged, the participants table on the admin page will not update if any participants are "cleaned up". This results in an error if you try to update again, or remove said participant.

<!-- Explain what you are changing and WHY you are changing it.
You should upload a picture of your changes if applicable. Drag & drop or paste from clipboard.
-->
This PR will set the fetch update hook in case any changes were made as a result of `reorderParticipants()`. This way the table updates automatically.
