### PR TITLE
✨ Add committees functionality (public listing, admin view)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
   StatsPage,
   TDBytesPage,
   SuggestionsPage,
+  KomitePage,
 } from 'components/pages';
 import { PrivateRoute, AuthorizationRoute, AdminRoute } from 'routes';
 import Navbar from 'components/molecules/navbar/Navbar';
@@ -66,6 +67,7 @@ const App: React.FC = () => {
               children={<ConfirmationPage />}
             />
             <Route path="/about-us" component={AboutPage} />
+            <Route path="/komite" component={KomitePage} />
             <Route path="/new-student" component={NewStudentsPage} />
             <PrivateRoute
               path="/tdbytes/suggestions"

--- a/src/api/committee.ts
+++ b/src/api/committee.ts
@@ -1,0 +1,99 @@
+import {
+  Committee,
+  CommitteeInput,
+  CommitteeUpdate,
+  CommitteeMemberInput,
+  CommitteeMemberListItem,
+  PaginatedResponse,
+} from 'models/apiModels';
+import { get, post, put, Delete } from './requests';
+
+// Query params for list endpoint
+export interface CommitteeListQuery {
+  status?: 'active' | 'inactive';
+  hasOpenSpots?: boolean;
+  q?: string;
+  sort?:
+    | 'name'
+    | 'createdAt'
+    | 'updatedAt'
+    | '-name'
+    | '-createdAt'
+    | '-updatedAt';
+  page?: number;
+  limit?: number; // max 100
+}
+
+export const listCommittees = (
+  query: CommitteeListQuery = {}
+): Promise<PaginatedResponse<Committee>> => {
+  // Convert boolean to string for query builder in requests.ts
+  const params: any = {};
+  if (query.status) params.status = query.status;
+  if (typeof query.hasOpenSpots === 'boolean')
+    params.hasOpenSpots = String(query.hasOpenSpots);
+  if (query.q) params.q = query.q;
+  if (query.sort) params.sort = query.sort;
+  if (query.page) params.page = String(query.page);
+  if (query.limit) params.limit = String(query.limit);
+  return get<PaginatedResponse<Committee>>('committee', params);
+};
+
+export const getCommittee = (id: string): Promise<Committee> =>
+  get<Committee>('committee/' + id);
+
+export const createCommittee = (input: CommitteeInput): Promise<Committee> =>
+  post<Committee>('committee', input);
+
+export const updateCommittee = (
+  id: string,
+  update: CommitteeUpdate
+): Promise<Committee> => put<Committee>('committee/' + id, update);
+
+export const deleteCommittee = (id: string): Promise<{}> =>
+  Delete<{}>('committee/' + id);
+
+export const listCommitteeMembers = (
+  id: string,
+  opts: { year?: number; page?: number; limit?: number } = {}
+): Promise<PaginatedResponse<CommitteeMemberListItem>> => {
+  const params: any = {};
+  if (opts.year) params.year = String(opts.year);
+  if (opts.page) params.page = String(opts.page);
+  if (opts.limit) params.limit = String(opts.limit);
+  return get<PaginatedResponse<CommitteeMemberListItem>>(
+    `committee/${id}/members`,
+    params
+  );
+};
+
+export const addCommitteeMember = (
+  id: string,
+  input: CommitteeMemberInput
+): Promise<{}> => post<{}>(`committee/${id}/members`, input);
+
+export const removeCommitteeMember = (
+  id: string,
+  userId: string,
+  year?: number
+): Promise<{}> => {
+  let path = `committee/${id}/members/${userId}`;
+  if (year) {
+    path += `?year=${year}`;
+  }
+  return Delete<{}>(path);
+};
+
+export const leaveCommitteeSelf = (id: string, year?: number): Promise<{}> => {
+  let path = `committee/${id}/members/self`;
+  if (year) {
+    path += `?year=${year}`;
+  }
+  return Delete<{}>(path);
+};
+
+// Apply to join a committee (sends email on backend)
+export const applyToCommittee = (
+  id: string,
+  payload: { message?: string }
+): Promise<{}> => post<{}>(`committee/${id}/apply`, payload);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,5 +2,6 @@ export * from './member';
 export * from './auth';
 export * from './event';
 export * from './stats';
+export * from './committee';
 
 export { get, post, put } from './requests';

--- a/src/components/atoms/select/select.module.scss
+++ b/src/components/atoms/select/select.module.scss
@@ -4,6 +4,7 @@
 // TODO: Use text.scss for some of this
 .container {
   outline: none;
+  width: 100%;
 }
 
 .wrapper {
@@ -11,14 +12,23 @@
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
+  width: 100%;
 }
 
 .text {
   line-height: normal;
-  // TODO: Find a better way than hardcoding pixels
-  height: 22px;
   position: relative;
   display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.8rem;
+  border: 2px solid $input-border;
+  background: $input-background;
+  border-radius: 5px;
+  color: $primary;
+  min-height: 44px;
+  box-sizing: border-box;
+  padding-right: 2.2rem; // space for dropdown icon
 }
 
 .icon {

--- a/src/components/atoms/textfield/textfield.module.scss
+++ b/src/components/atoms/textfield/textfield.module.scss
@@ -3,7 +3,8 @@
 .inputFlex {
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
+  width: 100%;
 }
 
 .inputPrefix {

--- a/src/components/molecules/footer/Footer.tsx
+++ b/src/components/molecules/footer/Footer.tsx
@@ -64,6 +64,7 @@ const Footer: React.FC = () => {
       <Flex justify="space-evenly" width={{ base: '100%', lg: '60%' }}>
         <FooterList header={'Ressurser'}>
           <FooterItem label={'Om TD'} path={'/about-us'} />
+          <FooterItem label={'Komitéer'} path={'/komite'} />
           <FooterItem
             label={'TD kalender'}
             path={

--- a/src/components/molecules/modal/modal.module.scss
+++ b/src/components/molecules/modal/modal.module.scss
@@ -59,6 +59,8 @@
 
 .modalContent {
   padding: 10px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .closeBtn {

--- a/src/components/molecules/navbar/Navbar.tsx
+++ b/src/components/molecules/navbar/Navbar.tsx
@@ -80,6 +80,7 @@ const Navbar: React.FC = () => {
       </div>
       <div className={styles.menuContainer}>
         <NavLink to="/jobs">Karriere</NavLink>
+        <NavLink to="/komite">Komitéer</NavLink>
         <NavLink to="/new-student">Ny Student</NavLink>
         {authenticated ? <AuthNavbar /> : <DefaultNavbar />}
       </div>

--- a/src/components/molecules/tables/committeeTable/CommitteeTable.tsx
+++ b/src/components/molecules/tables/committeeTable/CommitteeTable.tsx
@@ -1,0 +1,493 @@
+import { useEffect, useMemo, useState } from 'react';
+import Table, { ColumnDefinitionType } from 'components/atoms/table/Table';
+import styles from './committeeTable.module.scss';
+import Icon from 'components/atoms/icons/icon';
+import Modal from 'components/molecules/modal/Modal';
+import TextField from 'components/atoms/textfield/Textfield';
+import Select from 'components/atoms/select/Select';
+import { Button } from '@chakra-ui/react';
+import { useToast } from 'hooks/useToast';
+import useModal from 'hooks/useModal';
+import ConfirmationBox from 'components/molecules/confirmationBox/ConfirmationBox';
+import { isDeepEqual } from 'utils/general';
+import {
+  Committee,
+  CommitteeInput,
+  CommitteeMemberListItem,
+  CommitteeUpdate,
+  PaginatedResponse,
+} from 'models/apiModels';
+import {
+  listCommittees,
+  createCommittee,
+  updateCommittee,
+  deleteCommittee,
+  listCommitteeMembers,
+  addCommitteeMember,
+  removeCommitteeMember,
+} from 'api/committee';
+import { getMemberByEmail } from 'api/member';
+import Textarea from 'components/atoms/textarea/Textarea';
+
+const currentYear = new Date().getFullYear();
+
+const CommitteeTable = () => {
+  const [committees, setCommittees] = useState<Committee[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<Committee | undefined>();
+  const [selectedToDelete, setSelectedToDelete] = useState<
+    Committee | undefined
+  >();
+
+  // Create/Edit modal state
+  const {
+    isOpen: isOpenEdit,
+    onOpen: openEdit,
+    onClose: closeEdit,
+  } = useModal();
+  const [formValues, setFormValues] = useState<
+    CommitteeInput | CommitteeUpdate
+  >({
+    name: '',
+    description: '',
+    hasOpenSpots: true,
+    status: 'active',
+    slug: '',
+    email: '',
+  });
+  const [initialFormValues, setInitialFormValues] = useState<
+    CommitteeInput | CommitteeUpdate
+  >({});
+  const [isCreate, setIsCreate] = useState(true);
+  const [editError, setEditError] = useState<string | undefined>();
+
+  // Members modal state
+  const {
+    isOpen: isOpenMembers,
+    onOpen: openMembers,
+    onClose: closeMembers,
+  } = useModal();
+  const [members, setMembers] = useState<CommitteeMemberListItem[]>([]);
+  const [membersPage, setMembersPage] = useState(1);
+  const [membersTotal, setMembersTotal] = useState(0);
+  const [addMemberEmail, setAddMemberEmail] = useState('');
+
+  const { addToast } = useToast();
+  const {
+    isOpen: isOpenDelete,
+    onOpen: openDelete,
+    onClose: closeDelete,
+  } = useModal();
+
+  // Member removal confirmation state
+  const {
+    isOpen: isOpenRemoveMember,
+    onOpen: openRemoveMember,
+    onClose: closeRemoveMember,
+  } = useModal();
+  const [memberToRemove, setMemberToRemove] = useState<
+    CommitteeMemberListItem | undefined
+  >();
+
+  const fetchCommittees = async () => {
+    setLoading(true);
+    try {
+      const res = await listCommittees({ limit: 100, sort: 'name' });
+      setCommittees(res.items);
+    } catch (e) {
+      addToast({ title: 'Kunne ikke hente komiteer', status: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    setIsCreate(true);
+    setSelected(undefined);
+    setFormValues({
+      name: '',
+      description: '',
+      hasOpenSpots: true,
+      status: 'active',
+      slug: '',
+      email: '',
+    });
+    openEdit();
+  };
+
+  const openEditModal = (row: Committee) => {
+    setIsCreate(false);
+    setSelected(row);
+    const initialValues = {
+      name: row.name,
+      description: row.description ?? '',
+      hasOpenSpots: row.hasOpenSpots,
+      status: row.status,
+      slug: row.slug,
+      email: row.email ?? '',
+    };
+    setFormValues(initialValues);
+    setInitialFormValues(initialValues);
+    setEditError(undefined);
+    openEdit();
+  };
+
+  const submitEdit = async () => {
+    try {
+      if (isCreate) {
+        const payload: CommitteeInput = {
+          name: String(formValues.name || '').trim(),
+          description: formValues.description?.trim() || undefined,
+          hasOpenSpots: !!formValues.hasOpenSpots,
+          status: (formValues.status as any) || 'active',
+          slug: formValues.slug?.trim() || undefined,
+          email: formValues.email?.trim() || undefined,
+        };
+        await createCommittee(payload);
+        addToast({ title: 'Komité opprettet', status: 'success' });
+      } else if (selected) {
+        const update: CommitteeUpdate = {
+          name: formValues.name?.trim() || undefined,
+          description: formValues.description?.trim() || undefined,
+          hasOpenSpots: formValues.hasOpenSpots,
+          status: formValues.status,
+          slug: formValues.slug?.trim() || undefined,
+          email: formValues.email?.trim() || undefined,
+        };
+
+        if (!isDeepEqual(update, initialFormValues)) {
+          await updateCommittee(selected.id, update);
+          addToast({ title: 'Komité oppdatert', status: 'success' });
+        } else {
+          setEditError('Minst et felt må endres');
+          return;
+        }
+      }
+      closeEdit();
+      fetchCommittees();
+    } catch (e: any) {
+      if (e.statusCode === 409) {
+        addToast({ title: 'Slug er allerede i bruk', status: 'error' });
+      } else {
+        addToast({ title: 'Noe gikk galt', status: 'error' });
+      }
+    }
+  };
+
+  const openDeleteColumn = (row: Committee) => {
+    setSelectedToDelete(row);
+    openDelete();
+  };
+
+  const adminDeleteCommittee = async () => {
+    try {
+      if (!selectedToDelete) return;
+      await deleteCommittee(selectedToDelete.id);
+      addToast({ title: 'Komité slettet', status: 'success' });
+      fetchCommittees();
+    } catch {
+      addToast({ title: 'Kunne ikke slette komité', status: 'error' });
+    }
+    closeDelete();
+  };
+
+  const openMembersModal = async (row: Committee) => {
+    setSelected(row);
+    setMembersPage(1);
+    setAddMemberEmail('');
+    await fetchMembers(row.id, 1);
+    openMembers();
+  };
+
+  const fetchMembers = async (id: string, page?: number) => {
+    try {
+      const res: PaginatedResponse<CommitteeMemberListItem> =
+        await listCommitteeMembers(id, { page, limit: 50 });
+      setMembers(res.items);
+      setMembersTotal(res.total);
+      setMembersPage(res.page);
+    } catch {
+      addToast({ title: 'Kunne ikke hente medlemmer', status: 'error' });
+    }
+  };
+
+  const handleAddMember = async () => {
+    if (!selected) return;
+    try {
+      const { id } = await getMemberByEmail(addMemberEmail.trim());
+      await addCommitteeMember(selected.id, { userId: id });
+      addToast({ title: 'Medlem lagt til', status: 'success' });
+      await fetchMembers(selected.id, membersPage);
+      setAddMemberEmail('');
+    } catch (e: any) {
+      if (e.statusCode === 404) {
+        addToast({ title: 'Bruker ikke funnet', status: 'error' });
+      } else if (e.statusCode === 409) {
+        addToast({ title: 'Bruker allerede i komiteen', status: 'warning' });
+      } else if (e.statusCode === 400) {
+        addToast({
+          title: 'Komiteen har ikke åpne plasser',
+          status: 'warning',
+        });
+      } else {
+        addToast({ title: 'Kunne ikke legge til medlem', status: 'error' });
+      }
+    }
+  };
+
+  const openRemoveMemberModal = (member: CommitteeMemberListItem) => {
+    setMemberToRemove(member);
+    openRemoveMember();
+  };
+
+  const confirmRemoveMember = async () => {
+    if (!selected || !memberToRemove) return;
+    try {
+      await removeCommitteeMember(selected.id, memberToRemove.id);
+      addToast({ title: 'Medlem fjernet', status: 'success' });
+      await fetchMembers(selected.id, membersPage);
+      closeRemoveMember();
+    } catch (e: any) {
+      if (e.statusCode === 404) {
+        addToast({
+          title: 'Ingen aktivt medlemskap funnet',
+          status: 'warning',
+        });
+      } else {
+        addToast({ title: 'Kunne ikke fjerne medlem', status: 'error' });
+      }
+      closeRemoveMember();
+    }
+  };
+
+  useEffect(() => {
+    fetchCommittees();
+  }, []);
+
+  const columns: ColumnDefinitionType<Committee, keyof Committee>[] = [
+    { cell: 'name', header: 'Navn', type: 'string' },
+    { cell: 'slug', header: 'Slug', type: 'string' },
+    { cell: 'email', header: 'E-post', type: 'string' },
+    { cell: 'status', header: 'Status', type: 'string' },
+    {
+      cell: (row) => <>{row.hasOpenSpots ? 'Åpen' : 'Lukket'}</>,
+      header: 'Plasser',
+      type: 'string',
+    },
+    { cell: 'memberCount', header: 'Medlemmer (i år)', type: 'number' },
+    {
+      cell: (row) => (
+        <Icon type="users" size={2} onClick={() => openMembersModal(row)} />
+      ),
+      header: 'Medlemmer',
+    },
+    {
+      cell: (row) => (
+        <Icon type="cog" size={2} onClick={() => openEditModal(row)} />
+      ),
+      header: 'Rediger',
+    },
+    {
+      cell: (row) => (
+        <Icon type="trash" size={2} onClick={() => openDeleteColumn(row)} />
+      ),
+      header: 'Slett',
+    },
+  ];
+
+  const statusItems = useMemo(
+    () => [
+      { key: 'active', label: 'Aktiv', value: 'active' },
+      { key: 'inactive', label: 'Inaktiv', value: 'inactive' },
+    ],
+    []
+  );
+
+  return (
+    <div className={styles.form}>
+      <div
+        style={{
+          marginBottom: '1rem',
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'flex-end',
+        }}>
+        <Button variant="primary" onClick={openCreateModal}>
+          Ny komité
+        </Button>
+      </div>
+
+      <Table columns={columns} data={committees} />
+
+      {/* Delete confirmation modal */}
+      <Modal
+        title={`Er du sikker på at du vil slette ${selectedToDelete?.name}?`}
+        isOpen={isOpenDelete}
+        onClose={closeDelete}
+        minWidth={45}>
+        <ConfirmationBox
+          onAccept={adminDeleteCommittee}
+          onDecline={closeDelete}
+        />
+      </Modal>
+
+      {/* Create / Edit modal */}
+      <Modal
+        title={isCreate ? 'Opprett komité' : `Rediger komité`}
+        isOpen={isOpenEdit}
+        onClose={closeEdit}
+        minWidth={80}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            width: '100%',
+          }}>
+          <TextField
+            label="Navn"
+            value={String(formValues.name ?? '')}
+            onChange={(e) =>
+              setFormValues((v) => ({ ...v, name: e.target.value }))
+            }
+          />
+          <TextField
+            label="Slug (valgfri)"
+            value={String(formValues.slug ?? '')}
+            onChange={(e) =>
+              setFormValues((v) => ({ ...v, slug: e.target.value }))
+            }
+          />
+          <TextField
+            label="E-post"
+            value={String(formValues.email ?? '')}
+            onChange={(e) =>
+              setFormValues((v) => ({ ...v, email: e.target.value }))
+            }
+          />
+          <Textarea
+            label="Beskrivelse"
+            value={String(formValues.description ?? '')}
+            onChange={(e) =>
+              setFormValues((v) => ({ ...v, description: e.target.value }))
+            }
+          />
+          <Select
+            label="Status"
+            name="status"
+            items={statusItems}
+            value={String(formValues.status ?? 'active')}
+            onChange={(value) =>
+              setFormValues((v) => ({ ...v, status: value as any }))
+            }
+          />
+          <Select
+            label="Åpne plasser"
+            name="hasOpenSpots"
+            items={[
+              { key: 'true', label: 'Ja', value: 'true' },
+              { key: 'false', label: 'Nei', value: 'false' },
+            ]}
+            value={String(!!formValues.hasOpenSpots)}
+            onChange={(value) =>
+              setFormValues((v) => ({ ...v, hasOpenSpots: value === 'true' }))
+            }
+          />
+          {editError && (
+            <p style={{ color: 'red', margin: '0.5rem 0' }}>{editError}</p>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: '1rem',
+              width: '100%',
+            }}>
+            <Button variant="secondary" onClick={closeEdit}>
+              Avbryt
+            </Button>
+            <Button variant="primary" onClick={submitEdit}>
+              {isCreate ? 'Opprett' : 'Lagre'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Members modal */}
+      <Modal
+        title={`Medlemmer i ${selected?.name ?? ''}`}
+        isOpen={isOpenMembers}
+        onClose={closeMembers}
+        minWidth={80}>
+        <div style={{ paddingTop: '12px', paddingBottom: '12px' }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: '1rem',
+              alignItems: 'flex-end',
+              marginBottom: '1rem',
+            }}>
+            <TextField
+              label="Legg til med e-post"
+              value={addMemberEmail}
+              onChange={(e) => setAddMemberEmail(e.target.value)}
+            />
+            <Button variant="primary" onClick={handleAddMember}>
+              Legg til
+            </Button>
+          </div>
+
+          <table className={'table'}>
+            <thead>
+              <tr>
+                <th>Navn</th>
+                <th>E-post</th>
+                <th>Telefon</th>
+                <th>Rolle</th>
+                <th>Fjern</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.id}>
+                  <td>{m.realName}</td>
+                  <td>{m.email}</td>
+                  <td>{m.phone ?? '-'}</td>
+                  <td>{m.role}</td>
+                  <td>
+                    <Icon
+                      type="trash"
+                      onClick={() => openRemoveMemberModal(m)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div style={{ marginTop: '0.5rem' }}>
+            <span>
+              Viser {members.length} av {membersTotal}
+            </span>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Remove member confirmation modal */}
+      <Modal
+        title={`Fjern ${memberToRemove?.realName ?? 'medlem'} fra ${
+          selected?.name ?? 'komiteen'
+        }?`}
+        isOpen={isOpenRemoveMember}
+        onClose={closeRemoveMember}
+        minWidth={45}>
+        <ConfirmationBox
+          onAccept={confirmRemoveMember}
+          onDecline={closeRemoveMember}
+        />
+      </Modal>
+    </div>
+  );
+};
+
+export default CommitteeTable;

--- a/src/components/molecules/tables/committeeTable/committeeTable.module.scss
+++ b/src/components/molecules/tables/committeeTable/committeeTable.module.scss
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+}

--- a/src/components/molecules/tables/index.ts
+++ b/src/components/molecules/tables/index.ts
@@ -1,3 +1,4 @@
 import MemberTable from './memberTable/MemberTable';
 import EventTable from './eventTable/eventTable';
-export { MemberTable, EventTable };
+import CommitteeTable from './committeeTable/CommitteeTable';
+export { MemberTable, EventTable, CommitteeTable };

--- a/src/components/pages/aboutTD/About.tsx
+++ b/src/components/pages/aboutTD/About.tsx
@@ -49,119 +49,6 @@ const TDBoardPost: React.FC<IBoardPost> = ({ position, members, mail }) => {
   );
 };
 
-interface ICommitte {
-  name: string;
-  children?: React.ReactNode;
-}
-
-const Committe: React.FC<ICommitte> = ({ name, children }) => {
-  // committee description is passed as children
-  return (
-    <Center
-      borderRadius="lg"
-      bg="slate.600"
-      flexGrow={1}
-      p=".5rem"
-      w={{ base: '100%', lg: '40%' }}>
-      <Flex direction="column" justify="center" textAlign="center">
-        <Heading as="h3" size="lg">
-          {name}
-        </Heading>
-        {children}
-      </Flex>
-    </Center>
-  );
-};
-
-const TDcommittees: React.FC = () => {
-  return (
-    <Flex wrap="wrap" justify="space-between" gap="1rem">
-      <Committe name="Arrangementskomité">
-        <p>
-          {' '}
-          Arrangementskomiteen jobber med å planlegge og gjennomføre
-          forskjellige arrangementer, alt fra fester og skiturer til
-          musikkbingo. Er dette noe som høres spennende ut ta kontakt med oss på{' '}
-          <Link href="mailto:arrangementsansvarlig@td-uit.no" color="blue.400">
-            mail.
-          </Link>
-        </p>
-      </Committe>
-
-      <Committe name="Bedriftskomité">
-        <p>
-          Bedriftskomiteen jobber med å kontakte bedrifter og sette opp
-          bedriftsarrangementer i regi av TD. Har du lyst til å høre mer om
-          dette ta kontakt med{' '}
-          <Link href="mailto:bedriftskommunikasjon@td-uit.no" color="blue.400">
-            kommunikasjonsansvarlig.
-          </Link>
-        </p>
-      </Committe>
-      <Committe name="Nettsidekomité">
-        <p>
-          {' '}
-          Lyst til å lære frontend og backend utvikling eller bare gira på å
-          legge til noen features? Ta{' '}
-          <Link href="mailto:nettside-ansvarlig@td-uit.no" color="blue.400">
-            kontakt
-          </Link>{' '}
-          eller sjekk ut githuben vår for{' '}
-          <Link
-            href="https://github.com/td-org-uit-no/tdctl-frontend"
-            color="blue.400">
-            frontend
-          </Link>{' '}
-          og{' '}
-          <Link
-            href="https://github.com/td-org-uit-no/tdctl-api"
-            color="blue.400">
-            backend.{' '}
-          </Link>
-        </p>
-      </Committe>
-      <Committe name="TD på tapp">
-        <p>
-          {' '}
-          TD på tapp er TD sin ølbryggingskomité. Her brygges det øl til
-          forskjellige anledninger. Er du interessert i ølbrygging eller har
-          lyst til å bli med? send oss en{' '}
-          <Link href="mailto:studentkommunikasjon@td-uit.no" color="blue.400">
-            mail.
-          </Link>
-        </p>
-      </Committe>
-      <Committe name="UiT Hack">
-        <p>
-          TD arrangerer årlig sin egen CTF kalt{' '}
-          <Link href="https://uithack.no/" color="blue.400">
-            UiTHack
-          </Link>{' '}
-          og vi trenger folk til å være med på å lage forskjellige oppgaver. Det
-          kreves ingen forkunnskaper for å bidra med en artig oppgave! Er du
-          interessert i hacking og CTF, eller bare er nysgjerrig, ta kontakt med{' '}
-          <Link href="mailto:studentkommunikasjon@td-uit.no" color="blue.400">
-            teknisk ansvarlig.
-          </Link>
-        </p>
-      </Committe>
-      <Committe name="Fagkomité">
-        <p>
-          {' '}
-          Fagkomiteen jobber med faglige arrangementer. Du kan være med å
-          arrangere IoTD for å lære mer om elektronikk og mikrokontrollere,
-          3D-printing osv. eller bli med å arrangere faglige workshops,
-          TD-talks, programmeringseventer og annen faglig aktivitet du ønsker å
-          bidra til. Er dette noe som høres spennende ut? Ta kontakt med{' '}
-          <Link href="mailto:fagkomite@td-uit.no" color="blue.400">
-            fagansvarlig.
-          </Link>
-        </p>
-      </Committe>
-    </Flex>
-  );
-};
-
 const TDBoardContactInfo: React.FC = () => {
   return (
     <Flex wrap="wrap" justify="space-between" gap="1rem">
@@ -245,15 +132,6 @@ const About = () => {
           </Heading>
         </Center>
         <TDBoardContactInfo />
-        <Center>
-          <Heading
-            size="2xl"
-            textDecoration="underline"
-            textDecorationColor="red.td">
-            Komitéer
-          </Heading>
-        </Center>
-        <TDcommittees />
       </Box>
     </>
   );

--- a/src/components/pages/admin/AdminPage.tsx
+++ b/src/components/pages/admin/AdminPage.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import styles from './adminPage.module.scss';
-import { MemberTable, EventTable } from 'components/molecules/tables';
+import {
+  MemberTable,
+  EventTable,
+  CommitteeTable,
+} from 'components/molecules/tables';
 import Icon from 'components/atoms/icons/icon';
 
 const WIP = () => {
@@ -11,7 +15,7 @@ const WIP = () => {
     </div>
   );
 };
-type componentOptions = 'Members' | 'Events' | 'Announcements';
+type componentOptions = 'Members' | 'Events' | 'Committees' | 'Announcements';
 
 // TODO only allow componentOptions keys
 interface componentsDict {
@@ -45,6 +49,7 @@ const AdminPage = () => {
   const components = {
     Members: <MemberTable />,
     Events: <EventTable />,
+    Committees: <CommitteeTable />,
     Announcements: <WIP />,
   } as componentsDict;
 
@@ -62,6 +67,11 @@ const AdminPage = () => {
           onClick={() => setComponentKey('Events')}
           iconType="calendar"
           label="Events"
+        />
+        <SideBarItem
+          onClick={() => setComponentKey('Committees')}
+          iconType="sitemap"
+          label="Committees"
         />
         <SideBarItem
           onClick={() => setComponentKey('Announcements')}

--- a/src/components/pages/committees/Committees.tsx
+++ b/src/components/pages/committees/Committees.tsx
@@ -1,0 +1,246 @@
+import {
+  Flex,
+  Heading,
+  Center,
+  Text,
+  Spinner,
+  Box,
+  Badge,
+  Button,
+} from '@chakra-ui/react';
+import React, { useEffect, useState } from 'react';
+import { Committee } from 'models/apiModels';
+import { listCommittees, applyToCommittee } from 'api/committee';
+import Modal from 'components/molecules/modal/Modal';
+import TextField from 'components/atoms/textfield/Textfield';
+import Textarea from 'components/atoms/textarea/Textarea';
+import { AuthenticateContext, Roles } from 'contexts/authProvider';
+import { useToast } from 'hooks/useToast';
+import { useContext } from 'react';
+
+interface ICommitteProps {
+  children?: React.ReactNode;
+}
+
+const Committe: React.FC<ICommitteProps> = ({ children }) => {
+  return (
+    <Flex
+      direction="column"
+      borderRadius="lg"
+      overflow="hidden"
+      flexGrow={1}
+      w={{ base: '100%', lg: '40%' }}>
+      {children}
+    </Flex>
+  );
+};
+
+const Committees: React.FC = () => {
+  const [items, setItems] = useState<Committee[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedCommittee, setSelectedCommittee] = useState<Committee | null>(
+    null
+  );
+  const [isApplyOpen, setApplyOpen] = useState(false);
+  const [discord, setDiscord] = useState('');
+  const [motivation, setMotivation] = useState('');
+  const { authenticated, role } = useContext(AuthenticateContext);
+  const { addToast } = useToast();
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const res = await listCommittees({
+          status: 'active',
+          sort: 'name',
+          limit: 100,
+        });
+        setItems(res.items);
+      } catch (e) {
+        setError('Kunne ikke laste inn komitéer');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <Center>
+        <Spinner />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Center>
+        <Text>{error}</Text>
+      </Center>
+    );
+  }
+
+  if (!items || items.length === 0) {
+    return (
+      <Center>
+        <Text>Ingen komitéer tilgjengelig</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Flex wrap="wrap" justify="space-between" gap="1rem">
+      {items.map((c) => (
+        <Committe key={c.id}>
+          {/* Header with title and badge */}
+          <Box bg="gray.300" borderTopRadius="lg">
+            <Box p="1rem" pb={c.hasOpenSpots ? '0.5rem' : '1rem'}>
+              <Heading as="h3" size="lg" textAlign="center" color="blue.900">
+                {c.name}
+              </Heading>
+            </Box>
+            {c.hasOpenSpots && (
+              <Box
+                bg="green.500"
+                color="white"
+                textAlign="center"
+                p="0.5rem"
+                fontSize="sm"
+                fontWeight="bold"
+                letterSpacing="wide">
+                ÅPEN FOR MEDLEMMER
+              </Box>
+            )}
+          </Box>
+
+          {/* Content section */}
+          <Box
+            bg="slate.600"
+            p="1rem"
+            pt={c.hasOpenSpots ? '1.5rem' : '1rem'}
+            pb={c.hasOpenSpots ? '1rem' : '1.5rem'}
+            flex="1"
+            borderBottomRadius={!c.hasOpenSpots ? 'lg' : '0'}>
+            <Text textAlign="center" color="white">
+              {c.description || 'Ingen beskrivelse tilgjengelig.'}
+            </Text>
+          </Box>
+
+          {/* Button section */}
+          {c.hasOpenSpots && (
+            <Box bg="slate.600" px="1rem" pb="1rem" borderBottomRadius="lg">
+              <Button
+                width="100%"
+                size="sm"
+                onClick={() => {
+                  setSelectedCommittee(c);
+                  setDiscord('');
+                  setMotivation('');
+                  setApplyError(null);
+                  setApplyOpen(true);
+                }}
+                isDisabled={
+                  !authenticated ||
+                  !(role === Roles.member || role === Roles.admin)
+                }>
+                Søk om plass
+              </Button>
+            </Box>
+          )}
+        </Committe>
+      ))}
+
+      <Modal
+        title={`Søk på ${selectedCommittee?.name ?? ''}`}
+        isOpen={isApplyOpen}
+        onClose={() => setApplyOpen(false)}
+        minWidth={70}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            width: '100%',
+          }}>
+          <TextField
+            label="Discord brukernavn"
+            placeholder="f.eks. navnetmitt#1234"
+            value={discord}
+            onChange={(e) => setDiscord(e.target.value)}
+          />
+          <Textarea
+            label="Hvorfor vil du bli med?"
+            placeholder="Skriv noen setninger om hvorfor du vil bli med i komiteen"
+            value={motivation}
+            onChange={(e) => setMotivation(e.target.value)}
+            resize
+          />
+          {applyError && (
+            <Text color="red.300" fontSize="sm">
+              {applyError}
+            </Text>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: '1rem',
+            }}>
+            <Button variant="secondary" onClick={() => setApplyOpen(false)}>
+              Avbryt
+            </Button>
+            <Button
+              variant="primary"
+              isLoading={isSubmitting}
+              onClick={async () => {
+                if (!selectedCommittee) return;
+                setApplyError(null);
+                const combined =
+                  `Discord: ${discord}\nMessage: ${motivation}`.trim();
+                if (combined.length > 2000) {
+                  setApplyError('Meldingen er for lang (maks 2000 tegn).');
+                  return;
+                }
+                setSubmitting(true);
+                try {
+                  await applyToCommittee(selectedCommittee.id, {
+                    message: combined,
+                  });
+                  addToast({ title: 'Søknad sendt', status: 'success' });
+                  setApplyOpen(false);
+                } catch (e: any) {
+                  switch (e.statusCode) {
+                    case 400:
+                      setApplyError(
+                        'Komiteen tar ikke imot søknader nå eller melding mangler/for lang.'
+                      );
+                      break;
+                    case 401:
+                      setApplyError('Du må være innlogget for å søke.');
+                      break;
+                    case 404:
+                      setApplyError('Fant ikke komiteen.');
+                      break;
+                    default:
+                      setApplyError('Noe gikk galt. Prøv igjen senere.');
+                  }
+                } finally {
+                  setSubmitting(false);
+                }
+              }}
+              isDisabled={!discord || !motivation}>
+              Send
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Flex>
+  );
+};
+
+export default Committees;

--- a/src/components/pages/committees/KomitePage.tsx
+++ b/src/components/pages/committees/KomitePage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box, Center, Heading, VStack } from '@chakra-ui/react';
+import useTitle from 'hooks/useTitle';
+import Footer from 'components/molecules/footer/Footer';
+import Committees from './Committees';
+
+const KomitePage: React.FC = () => {
+  useTitle('Komitéer');
+  return (
+    <VStack>
+      <Center>
+        <Box width={{ base: '95vw', md: '70vw' }} mt="1rem" maxW={970}>
+          <Heading
+            size="2xl"
+            textDecoration="underline"
+            textDecorationColor="red.td">
+            Komitéer
+          </Heading>
+          <Box mt="1rem">
+            <Committees />
+          </Box>
+        </Box>
+      </Center>
+      <Footer />
+    </VStack>
+  );
+};
+
+export default KomitePage;

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -17,6 +17,7 @@ import NewStudentsPage from './newStudent/NewStudent';
 import TDBytesPage from './TDBytes/TDBytes';
 import SuggestionsPage from './TDBytes/ProductSuggestions';
 import StatsPage from './stats/StatsPage';
+import KomitePage from './committees/KomitePage';
 
 import Jobs from './jobs/Jobs';
 import Job from './jobs/Job';
@@ -44,4 +45,5 @@ export {
   TDBytesPage,
   SuggestionsPage,
   StatsPage,
+  KomitePage,
 };

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -193,3 +193,59 @@ export interface ProductSuggestion {
   timestamp: Date;
   username: string;
 }
+
+// Committee models
+export type CommitteeStatus = 'active' | 'inactive';
+
+export interface CommitteeInput {
+  name: string;
+  description?: string;
+  hasOpenSpots: boolean;
+  status: CommitteeStatus;
+  slug?: string;
+  email?: string;
+}
+
+export interface Committee {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  status: CommitteeStatus;
+  hasOpenSpots: boolean;
+  email?: string;
+  createdAt: string; // ISO
+  updatedAt: string; // ISO
+  createdBy: string; // email
+  memberCount: number; // current-year member count
+}
+
+export type CommitteeUpdate = Partial<CommitteeInput>;
+
+export interface CommitteeMemberInput {
+  userId: string;
+  year?: number; // defaults to current year on backend
+}
+
+export type CommitteeMemberRole =
+  | 'admin'
+  | 'member'
+  | 'unconfirmed'
+  | 'kiosk_admin';
+
+export interface CommitteeMemberListItem {
+  id: string;
+  realName: string;
+  email: string;
+  classYear: string;
+  phone?: string;
+  year: number;
+  role: CommitteeMemberRole;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+}


### PR DESCRIPTION
This PR introduces a complete committee management system for TD, replacing the hardcoded committee information with a dynamic, database-driven solution. The feature includes administrative controls for managing committees and their members, plus a public-facing page for students to browse and apply to committees.

## Motivation

**Problems Solved:**
- **Static Content Limitation:** Committee information was hardcoded in the About page, making updates require code changes and deployments
- **No Member Tracking:** No system to track which students are in which committees
- **Manual Application Process:** Students had to find Discord user of board members to join committees
- **Scalability Issues:** Adding new committees or updating descriptions required developer intervention
- 

## Changes Made

### **1. API Integration** 

**New Committee API Client:**
- `listCommittees()` - Fetch paginated/filtered committee list
- `getCommittee()` - Get single committee details
- `createCommittee()` - Admin committee creation
- `updateCommittee()` - Admin committee updates
- `deleteCommittee()` - Admin committee deletion

**Member Management:**
- `listCommitteeMembers()` - Get committee members by year
- `addCommitteeMember()` - Admin adds member to committee
- `removeCommitteeMember()` - Admin removes member from committee
- `leaveCommitteeSelf()` - Member leaves committee
- `applyToCommittee()` - Student applies to join committee

### **3. Admin Management UI** 
(src/components/molecules/tables/committeeTable/CommitteeTable.tsx)

**Features:**
- **Committee CRUD Operations:**
  - Create new committees with name, description, slug, email, status
  - Edit existing committee details
  - Delete committees with confirmation modal
  - View all committees in sortable table

- **Member Management:**
  - View committee members with pagination
  - Add members by email lookup
  - Remove members with confirmation
  - Display member count per committee

- **Form Controls:**
  - Text fields for name, slug, email
  - Textarea for description
  - Dropdowns for status (active/inactive) and open spots (yes/no)
  - Validation with error messages

### **6. Form Component Improvements**
There was some issues related to styling of components, therefore some atoms has been modified. 

**Select Component** ([src/components/atoms/select/select.module.scss](src/components/atoms/select/select.module.scss)):
- Added full-width support (`width: 100%`)
- Improved visual consistency with input fields
- Added proper padding, border, and background styling
- Fixed icon positioning with `padding-right: 2.2rem`
- Increased touch target size to 44px (WCAG compliant)

**TextField Component** ([src/components/atoms/textfield/textfield.module.scss](src/components/atoms/textfield/textfield.module.scss)):
- Changed flex alignment from `center` to `flex-start`
- Added full-width support for better form layouts

**Modal Component** ([src/components/molecules/modal/modal.module.scss](src/components/molecules/modal/modal.module.scss)):
- Added `width: 100%` and `box-sizing: border-box` to modal content
- Prevents overflow issues with wide form elements

**Why:** The existing form components didn't support the full-width layouts needed for the committee modals. These improvements make forms more usable and visually consistent.


## Known Limitations & Future Improvements

**Current Limitations:**
1. Large Component: CommitteeTable.tsx is 493 lines - could be split into smaller components
2. Pagination: Members table shows count but pagination controls incomplete
3. Search/Filter: No search functionality for committees list
4. Accessibility: Missing ARIA labels on icon buttons
5. Validation: Client-side validation limited (for now only to email, and slug format)

**Future Enhancements:**
- Committee roles (chair, vice-chair, member)
- Application workflow (pending/approved/rejected)
- Email notifications for applications
- Committee-specific pages (`/komite/:slug`)
- Member year history view
- Analytics dashboard (member trends, application stats)

## Migration Notes

**Action Required Post-Merge:**
1. **Migrate hardcoded committee data** from removed About.tsx section into database via admin panel
2. **Verify email addresses** for each committee are correct
3. **Set appropriate statuses** (active/inactive) for each committee
4. **Configure hasOpenSpots** based on current recruitment status
5. **Add existing committee members** through admin interface

**Data to Migrate:**
- Arrangementskomité → arrangementsansvarlig@td-uit.no
- Bedriftskomité → bedriftskommunikasjon@td-uit.no
- Nettsidekomité → nettside-ansvarlig@td-uit.no
- TD på tapp → studentkommunikasjon@td-uit.no
- UiT Hack → studentkommunikasjon@td-uit.no
- Fagkomité → fagkomite@td-uit.no


<img width="1067" height="502" alt="image" src="https://github.com/user-attachments/assets/29cac3a5-a118-4269-b039-e3800589990c" />
Public facing view of commitees

<img width="2020" height="510" alt="image" src="https://github.com/user-attachments/assets/78558955-cc6c-483d-b29c-0818238825a7" />
Admin view, table over comitees

<img width="1005" height="669" alt="image" src="https://github.com/user-attachments/assets/017844eb-a2c6-4b57-9da6-55921adef920" />
Create new commitee modal

<img width="985" height="483" alt="image" src="https://github.com/user-attachments/assets/b76f75de-39f7-4cda-b3a2-d99ea5af2700" />
View members in a commitee modal, add by email