### PR TITLE
✨ Add GDPR consent field to event registration

### DIFF
--- a/src/components/molecules/event/eventButton/EventButton.tsx
+++ b/src/components/molecules/event/eventButton/EventButton.tsx
@@ -41,6 +41,7 @@ const AuthEventButton: React.FC<AuthButtonProps> = ({
     food: false,
     transportation: false,
     dietaryRestrictions: '',
+    gdprConsent: false,
   });
   const { addToast } = useToast();
   const { isOpen, onOpen, onClose } = useModal();

--- a/src/components/molecules/event/eventPreferences/EventPreferences.tsx
+++ b/src/components/molecules/event/eventPreferences/EventPreferences.tsx
@@ -79,6 +79,16 @@ const EventPreferences: React.FC<EventPreferencesProps> = ({
           }}
         />
       )}
+      <ToggleButton
+        label={'Jeg godtar videresending av mine personopplysninger til bedriften i henhold til GDPR'}
+        initValue={prefs.gdprConsent}
+        onChange={() => {
+          changePrefs({
+            ...prefs,
+            gdprConsent: !prefs.gdprConsent,
+          });
+        }}
+      />
     </div>
   );
 };

--- a/src/components/molecules/event/eventResponses/EventResponses.tsx
+++ b/src/components/molecules/event/eventResponses/EventResponses.tsx
@@ -383,6 +383,19 @@ const EventResponses: React.FC<{
     },
     {
       cell: (cellValues) => {
+        const { gdprConsent } = cellValues;
+        return (
+          <>
+            <Icon
+              type={gdprConsent ? 'check' : 'ban'}
+              color={gdprConsent ? '#00ff00' : 'gray'}></Icon>
+          </>
+        );
+      },
+      header: 'GDPR',
+    },
+    {
+      cell: (cellValues) => {
         const { email } = cellValues;
         return (
           <>

--- a/src/components/molecules/event/myEventCard/myEventCard.tsx
+++ b/src/components/molecules/event/myEventCard/myEventCard.tsx
@@ -45,12 +45,14 @@ const MyEventCard: React.FC<MyEventCardProps> = ({ eventData }) => {
     food: false,
     transportation: false,
     dietaryRestrictions: '',
+    gdprConsent: false,
   });
   /* Payload to send */
   const [editPrefsPayload, setEditPrefsPayload] = useState<JoinEventPayload>({
     food: false,
     transportation: false,
     dietaryRestrictions: '',
+    gdprConsent: false,
   });
 
   /* Predefined statuses */
@@ -251,6 +253,14 @@ const MyEventCard: React.FC<MyEventCardProps> = ({ eventData }) => {
                   {options.dietaryRestrictions}
                   {' }'}
                 </span>
+              )}
+            </div>
+            <div>
+              GDPR Samtykke{' '}
+              {options.gdprConsent ? (
+                <Icon type={'check'} color={'green'} />
+              ) : (
+                <Icon type={'ban'} color={'red'} />
               )}
             </div>
           </div>

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -30,6 +30,7 @@ export interface Participant {
   food: boolean;
   transportation: boolean;
   dietaryRestrictions?: string;
+  gdprConsent: boolean;
   submitDate: string;
   penalty: number;
   confirmed?: boolean;
@@ -109,6 +110,7 @@ export interface JoinEventPayload {
   food?: boolean;
   transportation?: boolean;
   dietaryRestrictions?: string;
+  gdprConsent?: boolean;
 }
 
 export interface SetAttendancePayload {


### PR DESCRIPTION
- Add gdprConsent field to JoinEventPayload and Participant interfaces
- Add GDPR consent checkbox to EventPreferences component
- Initialize gdprConsent (default: false) in event join flow
- Display GDPR consent status in MyEventCard for registered events
- Add GDPR consent column to admin participant table
