### PR TITLE
✨Add waitlist-only option to event email popup

### DIFF
--- a/src/components/molecules/event/eventResponses/EventResponses.tsx
+++ b/src/components/molecules/event/eventResponses/EventResponses.tsx
@@ -119,6 +119,7 @@ const EventResponses: React.FC<{
 
   /* Email form */
   const [confirmedOnly, setConfirmedOnly] = useState<boolean>(false);
+  const [waitListOnly, setWaitListOnly] = useState<boolean>(false);
   const [mailError, setMailError] = useState<string | undefined>(undefined);
   const validators = {
     subject: mailSubjectValidator,
@@ -144,7 +145,9 @@ const EventResponses: React.FC<{
         subject: fields['subject']?.value,
         msg: fields['mail']?.value,
         confirmedOnly: confirmedOnly,
+        waitListOnly: waitListOnly,
       });
+
       addToast({
         title: 'Suksess',
         status: 'success',
@@ -165,7 +168,7 @@ const EventResponses: React.FC<{
     validators: validators,
   });
 
-  const calculateMailRecipients = () => {
+  const calculateNrMailRecipients = () => {
     if (!event.participants) {
       return 0;
     }
@@ -173,7 +176,10 @@ const EventResponses: React.FC<{
       if (confirmedOnly) {
         return p.confirmed === true;
       }
-      return !p.confirmed;
+      if (waitListOnly) {
+        return p.confirmed === false;
+      }
+      return true;
     });
 
     return recipients.length;
@@ -579,9 +585,18 @@ const EventResponses: React.FC<{
               <ToggleButton
                 onChange={() => {
                   setConfirmedOnly(!confirmedOnly);
+                  if (!confirmedOnly) setWaitListOnly(false);
                 }}
                 initValue={confirmedOnly}
                 label="Kun send til de med bekreftet plass"
+              />
+              <ToggleButton
+                onChange={() => {
+                  setWaitListOnly(!waitListOnly);
+                  if (!waitListOnly) setConfirmedOnly(false);
+                }}
+                initValue={waitListOnly}
+                label="Kun send til de på venteliste"
               />
             </Flex>
           </form>
@@ -593,8 +608,9 @@ const EventResponses: React.FC<{
               </Text>
             )}
             <Flex direction="column" justifyContent="end" mr={2}>
-              <Text fontSize="xs" fontStyle="italic" color="slate.400" m={0}>
-                Eposten vil bli sendt til {calculateMailRecipients()} studenter
+              <Text fontSize="s" fontStyle="italic" color="slate.400" m={0}>
+                Eposten vil bli sendt til {calculateNrMailRecipients()}{' '}
+                studenter
               </Text>
             </Flex>
             <Button variant="secondary" onClick={submitMail}>

--- a/src/models/apiModels.ts
+++ b/src/models/apiModels.ts
@@ -124,6 +124,7 @@ export interface EventMailPayload {
   subject: string;
   msg: string;
   confirmedOnly?: boolean;
+  waitListOnly?: boolean;
 }
 
 export interface JobItem {


### PR DESCRIPTION
# Add waitlist-only option to event email popup

Closes 321

Adds an extra toggle button to the send emails popup so that the admin can choose to send the email to either people who have confirmation, are on the waitlist, or everyone who signed up for the event. Also made the text that tells the admin how many people are getting emails a bit larger as to make it easier to read.
The buttons are also mutually exclusive.

Before:
<img width="730" height="309" alt="Screenshot 2025-10-27 at 23 15 32" src="https://github.com/user-attachments/assets/b83c97d4-3243-40eb-b19b-84eead23169b" />

After:
<img width="726" height="330" alt="Screenshot 2025-10-27 at 23 14 48" src="https://github.com/user-attachments/assets/c72177fe-e98f-4646-9a2c-9fcb023ff52b" />


